### PR TITLE
add ubuntu-clock-app example

### DIFF
--- a/ubuntu-clock-app/clock.wrapper
+++ b/ubuntu-clock-app/clock.wrapper
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+ARCH='x86_64-linux-gnu'
+
+export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH:$LD_LIBRARY_PATH
+
+# XKB config
+export XKB_CONFIG_ROOT=$SNAP/usr/share/X11/xkb
+
+# Qt Platform to Mir
+#export QT_QPA_PLATFORM=ubuntumirclient
+export QTCHOOSER_NO_GLOBAL_DIR=1
+export QT_SELECT=snappy-qt5
+
+# Qt Libs
+export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/qt5/libs:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/pulseaudio:$LD_LIBRARY_PATH
+
+# Qt Modules
+export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt5/plugins
+export QML2_IMPORT_PATH=$SNAP/usr/lib/$ARCH/qt5/qml/ClockApp
+export QML2_IMPORT_PATH=$QML2_IMPORT_PATH:$SNAP/usr/lib/$ARCH/qt5/qml
+export QML2_IMPORT_PATH=$QML2_IMPORT_PATH:$SNAP/lib/$ARCH
+
+# Mesa Libs
+export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/mesa:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/mesa-egl:$LD_LIBRARY_PATH
+
+# XDG Config
+export XDG_CONFIG_DIRS=$SNAP/etc/xdg:$XDG_CONFIG_DIRS
+export XDG_CONFIG_DIRS=$SNAP/usr/xdg:$XDG_CONFIG_DIRS
+# Note: this doesn't seem to work, QML's LocalStorage either ignores
+# or fails to use $SNAP_USER_DATA if defined here
+export XDG_DATA_DIRS=$SNAP_USER_DATA:$XDG_DATA_DIRS
+export XDG_DATA_DIRS=$SNAP/usr/share:$XDG_DATA_DIRS
+
+# Not good, needed for fontconfig
+export XDG_DATA_HOME=$SNAP/usr/share
+
+# Font Config
+export FONTCONFIG_PATH=$SNAP/etc/fonts/config.d
+export FONTCONFIG_FILE=$SNAP/etc/fonts/fonts.conf
+
+# Tell libGL where to find the drivers
+export LIBGL_DRIVERS_PATH=$SNAP/usr/lib/$ARCH/dri
+
+# Necessary for the SDK to find the translations directory
+export APP_DIR=$SNAP
+
+# ensure the snappy gl libs win
+export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
+
+cd $SNAP
+exec $SNAP/usr/bin/qmlscene $SNAP/usr/share/ubuntu-clock-app/ubuntu-clock-app.qml

--- a/ubuntu-clock-app/snapcraft.yaml
+++ b/ubuntu-clock-app/snapcraft.yaml
@@ -1,0 +1,50 @@
+name: ubuntu-clock-app
+version: 3.6+snap2
+summary: Ubuntu Clock app
+description: |
+   The clock app for all Ubuntu devices
+
+apps:
+  clock:
+    command: clock
+    plugs: [unity7,opengl]
+
+parts:
+  clock:
+    plugin: cmake
+    configflags: [-DCMAKE_INSTALL_PREFIX=/usr, -DCLICK_MODE=off]
+    source: lp:~dpm/ubuntu-clock-app/snap-all-things
+    source-type: bzr
+    build-packages:
+      - build-essential
+      - cmake
+      - gettext
+      - intltool
+      - ubuntu-touch-sounds
+      - suru-icon-theme
+      - qml-module-qttest
+      - qml-module-qtsysteminfo
+      - qml-module-qt-labs-settings
+      - qtdeclarative5-u1db1.0
+      - qtdeclarative5-qtmultimedia-plugin
+      - qtdeclarative5-qtpositioning-plugin
+      - qtdeclarative5-ubuntu-content1
+      - qt5-default
+      - qtbase5-dev
+      - qtdeclarative5-dev
+      - qtdeclarative5-dev-tools
+      - qtdeclarative5-folderlistmodel-plugin
+      - qtdeclarative5-ubuntu-ui-toolkit-plugin
+      - xvfb
+    stage-packages:
+      - ubuntu-sdk-libs
+      - qtubuntu-desktop
+      - qml-module-qtsysteminfo
+    snap:
+      - -usr/share/doc
+      - -usr/include
+  environment:
+    plugin: copy
+    files:
+      clock.wrapper: bin/clock
+      snappy-qt5.conf: etc/xdg/qtchooser/snappy-qt5.conf

--- a/ubuntu-clock-app/snappy-qt5.conf
+++ b/ubuntu-clock-app/snappy-qt5.conf
@@ -1,0 +1,2 @@
+./usr/lib/x86_64-linux-gnu/qt5/bin
+./usr/lib/x86_64-linux-gnu


### PR DESCRIPTION
Add `ubuntu-clock-app` example from snappy-desktop-examples.