### PR TITLE
Change of location of ffmpeg binaries

### DIFF
--- a/youtube-dl/snapcraft.yaml
+++ b/youtube-dl/snapcraft.yaml
@@ -49,3 +49,5 @@ parts:
       - libopus-dev
       - libx265-dev
       - libvpx-dev
+    organize:
+      usr/local/bin: usr/bin


### PR DESCRIPTION
ffmpeg binaries go to usr/local/bin but youtube-dl is launched from usr/bin. ffprobe can't be launch when converting to mp3