### PR TITLE
Ensure we only run once per project, and ignore subdirectories

### DIFF
--- a/ci-run
+++ b/ci-run
@@ -11,6 +11,9 @@ fi
 root_dir=`pwd`
 return_code=0
 for dir in $projects_to_test; do
+    # Don't include files in root directory
+    [ ! -d $dir ] && continue
+
     echo "Testing $dir"
     cd ${root_dir}/$dir
     docker run -v $(pwd):/snapcraft -t sergiusens/snapcraft sh -c "cd /snapcraft && snapcraft"

--- a/ci-run
+++ b/ci-run
@@ -5,7 +5,7 @@ current_branch=`git rev-parse --abbrev-ref HEAD`
 
 projects_to_test=`find * -maxdepth 0 -type d`
 if [ "$current_branch" != "master" ]; then
-    projects_to_test=`git diff --name-only master..$current_branch | sed -n 's#\(.*\)/.*#\1#p'`
+    projects_to_test=`git diff --name-only master..$current_branch | sed -n 's#\([^/]*\).*#\1#p' | sort -u`
 fi
 
 root_dir=`pwd`


### PR DESCRIPTION
Change regexp so that we ignore subdirectories in the list and sort them to
keep the directory list unique (and so, don't run the same thing twice)