### PR TITLE
TeXworks working snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This project currently includes the following snaps:
 | :white_check_mark:  | `scummvm`          |                           | autotools                 |
 | :white_check_mark:  | `shotwell`         |                           | autotools, vala           |
 | :white_check_mark:  | `smplayer`         |                           | qt5, stage-package        |
+| :white_check_mark:  | `texworks`         |                           | copy, qt4,                |
 | :white_check_mark:  | `tinyproxy`        |                           | copy, daemon, stage-package |
 | :white_check_mark:  | `tyrant-unleashed-optimizer` |                 | make                      |
 | :white_check_mark:  | `ubuntu-clock-app` | [ubuntu-clock-app][clock] | qmake, qt5                |

--- a/texworks/README.md
+++ b/texworks/README.md
@@ -1,17 +1,16 @@
 # TeXworks snap
 
-This project creates a non working snap of TeXworks built from git.
-texlive is not included.
+This project creates a working snap of TeXworks built from git.
+texlive is included from upstream.
 
 ## Current state
 
 Working features:
-  - Editor starts
+  - Everything
 
 Known issues:
-  - texlive folder not recognized properly:
-    - files in usr/share/texmf, program searches share/texmf 
-  - qt theme not recognized
+  - if installed without --devmode the menu is not visible (tested only on unity7)
+  - You need to confirm the texlive install
 
 TODO:
- 
+ Check menu without --devmode

--- a/texworks/README.md
+++ b/texworks/README.md
@@ -1,4 +1,4 @@
-# ScummVM snap
+# TeXworks snap
 
 This project creates a working snap of TeXworks built from git.
 texlive is not included.

--- a/texworks/README.md
+++ b/texworks/README.md
@@ -10,7 +10,6 @@ Working features:
 
 Known issues:
   - if installed without --devmode the menu is not visible (tested only on unity7)
-  - You need to confirm the texlive install
 
 TODO:
  Check menu without --devmode

--- a/texworks/README.md
+++ b/texworks/README.md
@@ -1,0 +1,15 @@
+# ScummVM snap
+
+This project creates a working snap of TeXworks built from git.
+texlive is not included.
+
+## Current state
+
+Working features:
+  - Editor
+
+Known issues:
+  - qt theme not recognized
+
+TODO:
+ 

--- a/texworks/README.md
+++ b/texworks/README.md
@@ -1,14 +1,16 @@
 # TeXworks snap
 
-This project creates a working snap of TeXworks built from git.
+This project creates a non working snap of TeXworks built from git.
 texlive is not included.
 
 ## Current state
 
 Working features:
-  - Editor
+  - Editor starts
 
 Known issues:
+  - texlive folder not recognized properly:
+    - files in usr/share/texmf, program searches share/texmf 
   - qt theme not recognized
 
 TODO:

--- a/texworks/parts/plugins/x-texlive.py
+++ b/texworks/parts/plugins/x-texlive.py
@@ -1,0 +1,20 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+import os
+
+import snapcraft
+from snapcraft.plugins import copy
+
+class TexLivePlugin(snapcraft.plugins.copy.CopyPlugin):
+
+    def build(self):
+        super(copy.CopyPlugin, self).build()
+
+        # Install TexLive with the standard installer
+        env = self._build_environment()
+        self.run(['{}/install-tl'.format(self.builddir), '-portable', '-scheme', 'basic'], env=env)
+
+
+    def _build_environment(self):
+        env = os.environ.copy()
+        env['TEXLIVE_INSTALL_PREFIX'] = self.installdir
+        return env

--- a/texworks/parts/plugins/x-texlive.py
+++ b/texworks/parts/plugins/x-texlive.py
@@ -11,10 +11,10 @@ class TexLivePlugin(snapcraft.plugins.copy.CopyPlugin):
 
         # Install TexLive with the standard installer
         env = self._build_environment()
-        self.run(['{}/install-tl'.format(self.builddir), '-portable', '-scheme', 'basic'], env=env)
+        self.run(['{}/install-tl'.format(self.builddir), '-scheme', 'basic'], env=env)
 
 
     def _build_environment(self):
         env = os.environ.copy()
-        env['TEXLIVE_INSTALL_PREFIX'] = self.installdir
+        env['TEXLIVE_INSTALL_PREFIX'] = os.path.join(self.installdir, 'usr', 'local')
         return env

--- a/texworks/parts/plugins/x-texlive.py
+++ b/texworks/parts/plugins/x-texlive.py
@@ -1,5 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 import os
+from subprocess import Popen, PIPE
 
 import snapcraft
 from snapcraft.plugins import copy
@@ -11,7 +12,10 @@ class TexLivePlugin(snapcraft.plugins.copy.CopyPlugin):
 
         # Install TexLive with the standard installer
         env = self._build_environment()
-        self.run(['{}/install-tl'.format(self.builddir), '-scheme', 'basic'], env=env)
+        #self.run(['{}/install-tl'.format(self.builddir), '-scheme', 'basic'], env=env)
+        p1 = Popen(['echo', '-n', 'I'], env=env, stdout=PIPE)
+        p2 = Popen(['{}/install-tl'.format(self.builddir), '-portable', '-scheme', 'basic'], env=env, stdin=p1.stdout, stdout=PIPE)
+        output = p2.communicate()[0]
 
 
     def _build_environment(self):

--- a/texworks/snapcraft.yaml
+++ b/texworks/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
   TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents,
   with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean,
   simple interface accessible to casual and non-technical users.
-confinement: strict
+confinement: devmode
 
 apps:
   texworks:

--- a/texworks/snapcraft.yaml
+++ b/texworks/snapcraft.yaml
@@ -2,7 +2,7 @@ name: texworks
 version: git
 summary: TeXworks 
 description: TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents, with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, simple interface accessible to casual and non-technical users.
-confinement: strict
+confinement: devmode
 
 apps:
   texworks:
@@ -10,34 +10,47 @@ apps:
     plugs: [home, x11, unity7]
 
 parts:
-    qt4conf:
-        build-packages: [dpkg-dev]
-        plugin: make
-        source: https://github.com/kyrofa/qt4conf.git
-    texworks:
-        plugin: cmake
-        source: https://github.com/TeXworks/texworks.git
-        source-type: git
-        build-packages:
-          - build-essential
-          - libpoppler-qt4-dev
-          - libpoppler-dev
-          - libfontconfig1-dev
-          - libhunspell-dev
-          - libdbus-1-dev
-          - liblua5.1-0-dev
-          - zlib1g-dev
-        stage-packages:
-          - libc6
-          - libgcc1
-          - libhunspell-1.3-0
-          - libpoppler-qt4-4
-          - libqt4-dbus
-          - libqt4-script
-          - libqt4-scripttools
-          - libqt4-xml
-          - libqtcore4
-          - libqtgui4
-          - libstdc++6
-          - libsynctex1
-          - fontconfig
+  qt4conf:
+    build-packages: [dpkg-dev]
+    plugin: make
+    source: https://github.com/kyrofa/qt4conf.git
+  texworks:
+    plugin: cmake
+    source: https://github.com/TeXworks/texworks.git
+    source-type: git
+    build-packages:
+      - build-essential
+      - libpoppler-qt4-dev
+      - libpoppler-dev
+      - libfontconfig1-dev
+      - libhunspell-dev
+      - libdbus-1-dev
+      - liblua5.1-0-dev
+      - zlib1g-dev
+    stage-packages:
+      - libc6
+      - libgcc1
+      - libdbus-1-3
+      - liblcms2-2
+      - libpng12-0
+      - libhunspell-1.3-0
+      - libpoppler-qt4-4
+      - libqt4-dbus
+      - libqt4-script
+      - libqt4-scripttools
+      - libqt4-xml
+      - libqtcore4
+      - libqtgui4
+      - libstdc++6
+      - libsynctex1
+      - fontconfig
+      - gsfonts
+      - lmodern
+      - poppler-data
+      - tex-common
+      - texlive-base
+      - texlive-binaries
+      - texlive-latex-base
+      - texlive-latex-base-doc
+    organize:
+      usr/share/texmf: share/texmf

--- a/texworks/snapcraft.yaml
+++ b/texworks/snapcraft.yaml
@@ -1,0 +1,40 @@
+name: texworks
+version: git
+summary: TeXworks 
+description: TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents, with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, simple interface accessible to casual and non-technical users.
+confinement: strict
+
+apps:
+  texworks:
+    command: qt4-launch bin/texworks
+    plugs: [home, x11, unity7]
+
+parts:
+    qt4conf:
+        build-packages: [dpkg-dev]
+        plugin: make
+        source: https://github.com/kyrofa/qt4conf.git
+    texworks:
+        plugin: cmake
+        source: https://github.com/TeXworks/texworks.git
+        source-type: git
+        build-packages:
+          - libpoppler-qt4-dev
+          - libhunspell-dev
+          - libdbus-1-dev
+          - liblua5.1-0-dev
+          - zlib1g-dev
+        stage-packages:
+          - libc6
+          - libgcc1
+          - libhunspell-1.3-0
+          - libpoppler-qt4-4
+          - libqt4-dbus
+          - libqt4-script
+          - libqt4-scripttools
+          - libqt4-xml
+          - libqtcore4
+          - libqtgui4
+          - libstdc++6
+          - libsynctex1
+          - fontconfig

--- a/texworks/snapcraft.yaml
+++ b/texworks/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: texworks
-version: git
+version: "0.6.1"
 summary: TeXworks
 description: |
   TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents,

--- a/texworks/snapcraft.yaml
+++ b/texworks/snapcraft.yaml
@@ -19,7 +19,10 @@ parts:
         source: https://github.com/TeXworks/texworks.git
         source-type: git
         build-packages:
+          - build-essential
           - libpoppler-qt4-dev
+          - libpoppler-dev
+          - libfontconfig1-dev
           - libhunspell-dev
           - libdbus-1-dev
           - liblua5.1-0-dev

--- a/texworks/snapcraft.yaml
+++ b/texworks/snapcraft.yaml
@@ -1,33 +1,35 @@
 name: texworks
 version: git
-summary: TeXworks 
-description: TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents, with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, simple interface accessible to casual and non-technical users.
+summary: TeXworks
+description: |
+  TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents,
+  with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean,
+  simple interface accessible to casual and non-technical users.
 
 apps:
   texworks:
-    command: qt4-launch bin/texworks
+    command: desktop-launch $SNAP/bin/texworks
     plugs: [home, x11, unity7]
 
 parts:
   texworks:
     plugin: cmake
     source: https://github.com/TeXworks/texworks.git
-    source-type: git
+    source-tag: release-0.6.1
     build-packages:
-      - build-essential
-      - libpoppler-qt4-dev
-      - libpoppler-dev
-      - libfontconfig1-dev
+      - debhelper
+      - pkg-config
+      - cmake
       - libhunspell-dev
-      - libdbus-1-dev
-      - liblua5.1-0-dev
+      - qtbase5-dev
+      - libpoppler-qt5-dev
+      - liblua5.2-dev
+      - python-dev
       - zlib1g-dev
+      - libsynctex-dev
     stage-packages:
       - libc6
       - libgcc1
-      - libdbus-1-3
-      - liblcms2-2
-      - libpng12-0
       - libhunspell-1.3-0
       - libpoppler-qt4-4
       - libqt4-dbus
@@ -38,25 +40,10 @@ parts:
       - libqtgui4
       - libstdc++6
       - libsynctex1
-      - fontconfig
-      - gsfonts
-      - poppler-data
-#      - lmodern
-#      - tex-common
-#      - texlive-base
-#      - texlive-binaries
-#      - texlive-latex-base
-#      - texlive-latex-base-doc
-  texlive:
-    plugin: texlive
-    source: http://ctan.mirror.garr.it/mirrors/CTAN/systems/texlive/Source/texlive-20160520-source.tar.xz
-    source-type: tar
-    build-packages:
-      - libfontconfig1-dev
-      - libx11-dev
-      - libxmu-dev
-      - libxaw7-dev
-#    organize:
-#     usr/share/texmf: share/texmf
-#      usr/share/texlive: share/texlive
-    after: [qt4conf]
+      - lmodern
+      - tex-common
+      - texlive-base
+      - texlive-binaries
+      - texlive-latex-base
+      - texlive-latex-base-doc
+    after: [desktop/qt5]

--- a/texworks/snapcraft.yaml
+++ b/texworks/snapcraft.yaml
@@ -5,14 +5,18 @@ description: |
   TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents,
   with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean,
   simple interface accessible to casual and non-technical users.
-confinement: devmode
+confinement: strict
 
 apps:
   texworks:
-    command: desktop-launch $SNAP/bin/texworks
+    command: texworks-launcher
     plugs: [home, x11, unity7]
 
 parts:
+  texworks-launcher:
+    plugin: copy
+    files:
+      texworks-launcher: bin/texworks-launcher
   texworks:
     plugin: cmake
     source: https://github.com/TeXworks/texworks.git

--- a/texworks/snapcraft.yaml
+++ b/texworks/snapcraft.yaml
@@ -2,7 +2,6 @@ name: texworks
 version: git
 summary: TeXworks 
 description: TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents, with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, simple interface accessible to casual and non-technical users.
-confinement: devmode
 
 apps:
   texworks:
@@ -10,10 +9,6 @@ apps:
     plugs: [home, x11, unity7]
 
 parts:
-  qt4conf:
-    build-packages: [dpkg-dev]
-    plugin: make
-    source: https://github.com/kyrofa/qt4conf.git
   texworks:
     plugin: cmake
     source: https://github.com/TeXworks/texworks.git
@@ -45,12 +40,23 @@ parts:
       - libsynctex1
       - fontconfig
       - gsfonts
-      - lmodern
       - poppler-data
-      - tex-common
-      - texlive-base
-      - texlive-binaries
-      - texlive-latex-base
-      - texlive-latex-base-doc
-    organize:
-      usr/share/texmf: share/texmf
+#      - lmodern
+#      - tex-common
+#      - texlive-base
+#      - texlive-binaries
+#      - texlive-latex-base
+#      - texlive-latex-base-doc
+  texlive:
+    plugin: texlive
+    source: http://ctan.mirror.garr.it/mirrors/CTAN/systems/texlive/Source/texlive-20160520-source.tar.xz
+    source-type: tar
+    build-packages:
+      - libfontconfig1-dev
+      - libx11-dev
+      - libxmu-dev
+      - libxaw7-dev
+#    organize:
+#     usr/share/texmf: share/texmf
+#      usr/share/texlive: share/texlive
+    after: [qt4conf]

--- a/texworks/snapcraft.yaml
+++ b/texworks/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents,
   with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean,
   simple interface accessible to casual and non-technical users.
+confinement: devmode
 
 apps:
   texworks:
@@ -17,16 +18,19 @@ parts:
     source: https://github.com/TeXworks/texworks.git
     source-tag: release-0.6.1
     build-packages:
+      - gcc
+      - g++
       - debhelper
       - pkg-config
       - cmake
       - libhunspell-dev
-      - qtbase5-dev
-      - libpoppler-qt5-dev
+      - libqt4-dev
+      - libpoppler-qt4-dev
       - liblua5.2-dev
       - python-dev
       - zlib1g-dev
       - libsynctex-dev
+      - libfontconfig1-dev
     stage-packages:
       - libc6
       - libgcc1
@@ -39,11 +43,12 @@ parts:
       - libqtcore4
       - libqtgui4
       - libstdc++6
-      - libsynctex1
-      - lmodern
-      - tex-common
-      - texlive-base
-      - texlive-binaries
-      - texlive-latex-base
-      - texlive-latex-base-doc
-    after: [desktop/qt5]
+      - zlib1g
+    after: [desktop/qt4]
+  texlive:
+    plugin: texlive
+    source: http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+    files:
+      '*': './'
+    build-packages:
+      - wget

--- a/texworks/texworks-launcher
+++ b/texworks/texworks-launcher
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+export PATH="$SNAP/usr/local/2016/bin/x86_64-linux/:$PATH"
+desktop-launch texworks

--- a/texworks/texworks-launcher
+++ b/texworks/texworks-launcher
@@ -1,4 +1,4 @@
 #! /bin/sh
 
-export PATH="$SNAP/usr/local/2016/bin/x86_64-linux/:$PATH"
+export PATH="$SNAP/usr/local/bin/x86_64-linux/:$PATH"
 desktop-launch texworks


### PR DESCRIPTION
At the moment it needs a copy of texlive.
It wouldn't be bad to have a snap for that as well.
To access a local copy of texlive not installed in $HOME it needs to be installed with --devmode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ubuntu/snappy-playpen/61)
<!-- Reviewable:end -->
