### PR TITLE
Initial mate-desktop snap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project currently includes the following snaps:
 | :white_check_mark:  | `keepassx`         | [keepassx-elopio][]       |
 | :white_check_mark:  | `kpcli`            | [kpcli-elopio][kpcli]     |
 | :white_check_mark:  | `leafpad`          |                           |
+| :red_circle:        | `mate-deskop`      |                           |
 | :white_check_mark:  | `minetest`         |                           |
 | :white_check_mark:  | `moon-buggy`       | [moon-buggy][moon-buggy]  |
 | :white_check_mark:  | `mpv`              |                           |

--- a/mate-desktop/README.md
+++ b/mate-desktop/README.md
@@ -1,0 +1,53 @@
+# MATE Desktop snap
+
+This project attempts to create a working snap of the complete MATE Desktop
+environment. The initial objective is to get just the main applications
+running.
+
+## Current state
+
+The components are listed in build order.
+
+Bits that build:
+
+  * mate-common
+  * mate-desktop
+  * mate-user-guide
+
+Bit to build:
+
+  * libmatekbd (currently fails)
+  * libmatemixer
+  * libmateweather
+  * mate-icon-theme
+  * caja
+  * mate-polkit
+  * marco
+  * mate-settings-daemon
+  * mate-session-manager
+  * mate-menus
+  * mate-panel
+  * mate-backgrounds
+  * mate-themes
+  * mate-notification-daemon
+  * mate-control-center
+  * mate-screensaver
+  * mate-media
+  * mate-power-manager
+  * mate-system-monitor
+  * atril
+  * caja-dropbox
+  * caja-extensions
+  * engrampa
+  * eom
+  * mate-applets
+  * mate-icon-theme-faenza
+  * mate-indicator-applet
+  * mate-netbook
+  * mate-sensors-applet
+  * mate-terminal
+  * mate-user-share
+  * mate-utils
+  * mozo
+  * pluma
+  * python-caja

--- a/mate-desktop/README.md
+++ b/mate-desktop/README.md
@@ -50,7 +50,14 @@ The components are listed in build order.
   * pluma                       [ BUILDS ]
   * python-caja
 
-## Conflict
+## FTBFS
+
+### libmatekbd
+
+Can't find `libmatedesktop-2.0`, complete error message will be added here in 
+due course.
+
+## Conflicts
 
 ### mate-icon-theme
 

--- a/mate-desktop/README.md
+++ b/mate-desktop/README.md
@@ -1,25 +1,23 @@
 # MATE Desktop snap
 
-This project attempts to create a working snap of the complete MATE Desktop
-environment. The initial objective is to get just the main applications
+This project attempts to create a working snap of the complete MATE Desktop 
+environment. The initial objective is to get just the main applications 
 running.
+
+This is a multi-part snap because the MATE packages in the Xenial archive are 
+built against GTK2 and I want to test MATE git master built against GTK3.
 
 ## Current state
 
 The components are listed in build order.
 
-Bits that build:
-
-  * mate-common
-  * mate-desktop
-  * mate-user-guide
-
-Bit to build:
-
-  * libmatekbd (currently fails)
-  * libmatemixer
+  * mate-common                 [ BUILDS ]
+  * mate-desktop                [ BUILDS ]
+  * mate-user-guide             [ BUILDS ]
+  * libmatekbd                  [ FAILS ]
+  * libmatemixer                [ BUILDS ]
   * libmateweather
-  * mate-icon-theme
+  * mate-icon-theme             [ CONFLICTS ]
   * caja
   * mate-polkit
   * marco
@@ -49,5 +47,13 @@ Bit to build:
   * mate-user-share
   * mate-utils
   * mozo
-  * pluma
+  * pluma                       [ BUILDS ]
   * python-caja
+
+## Conflict
+
+### mate-icon-theme
+
+    Parts 'mate-user-guide' and 'mate-icon-theme' have the following file
+    paths in common which have different contents: usr/sbin/update-icon-
+    caches

--- a/mate-desktop/README.md
+++ b/mate-desktop/README.md
@@ -12,7 +12,7 @@ built against GTK2 and I want to test MATE git master built against GTK3.
 The components are listed in build order.
 
   * mate-common                 [ BUILDS ]
-  * mate-desktop                [ BUILDS ]
+  * mate-desktop                [ EXECUTES ]
   * mate-user-guide             [ BUILDS ]
   * libmatekbd                  [ FAILS ]
   * libmatemixer                [ BUILDS ]
@@ -32,7 +32,7 @@ The components are listed in build order.
   * mate-screensaver
   * mate-media
   * mate-power-manager
-  * mate-system-monitor
+  * mate-system-monitor         [ BUILDS ]
   * atril
   * caja-dropbox
   * caja-extensions

--- a/mate-desktop/snapcraft.yaml
+++ b/mate-desktop/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mate-desktop
-version: 1.15
+version: 1.15.0~git
 summary: MATE Desktop Environment
 description: |
    The MATE Desktop Environment is the continuation of GNOME 2. It
@@ -10,24 +10,41 @@ description: |
 confinement: devmode
 
 apps:
+  # From mate-desktop
   mate-about:
     command: gtk-launch mate-about
     plugs:
       - home
       - x11
 
+  # From mate-desktop
+  mate-color-select:
+    command: gtk-launch mate-color-select
+    plugs:
+      - home
+      - x11
+
+  # From mate-system-monitor
+  mate-system-monitor:
+    command: gtk-launch mate-system-monitor
+    plugs:
+      - home
+      - network
+      - x11
+
+  # From pluma
   pluma:
     command: gtk-launch pluma
     plugs:
       - home
       - x11
 
-build-packages:
-  - gettext
-  - gtk-doc-tools
-  - intltool
-  - libtool
-  - pkg-config
+#build-packages:
+#  - gettext
+#  - gtk-doc-tools
+#  - intltool
+#  - libtool
+#  - pkg-config
 
 parts:
   mate-common:
@@ -86,24 +103,129 @@ parts:
     stage-packages:
       - yelp
 
-  libmatekbd:
+# Fails to build, see README.md
+#  libmatekbd:
+#    plugin: autotools
+#    source: https://github.com/mate-desktop/libmatekbd.git
+#    after: [ mate-common, mate-desktop, gtkconf ]
+#    configflags:
+#      - --disable-silent-rules
+#      - --disable-static
+#      - --enable-introspection
+#      - --with-gtk=3.0
+#    install-via: prefix
+#    build-packages:
+#      - intltool
+#      - libgirepository1.0-dev
+#      - libglib2.0-dev
+#      - libgtk-3-dev
+#      - libxklavier-dev
+#    stage-packages:
+#      - iso-codes
+#      - libglib2.0-0
+#      - libgtk-3-0
+#      - libxklavier16
+
+  libmatemixer:
     plugin: autotools
-    source: https://github.com/mate-desktop/libmate.git
-    after: [ mate-common, mate-desktop, gtkconf ]
+    source: https://github.com/mate-desktop/libmatemixer.git
+    after: [ mate-common ]
     configflags:
       - --disable-silent-rules
       - --disable-static
-      - --enable-introspection
+      - --enable-gtk-doc
+    install-via: prefix
+    build-packages:
+      - libasound2-dev
+      - libglib2.0-dev
+      - libpulse-dev
+    stage-packages:
+      - iso-codes
+      - libasound2
+      - libglib2.0-0
+      - libpulse0
+
+  libmateweather:
+    plugin: autotools
+    source: https://github.com/mate-desktop/libmateweather.git
+    after: [ mate-common ]
+    configflags:
+      - --disable-schemas-compile
+      - --disable-silent-rules
+      - --disable-static
+      - --enable-gtk-doc
+    install-via: prefix
+    build-packages:
+      - libglib2.0-dev
+      - libgtk-3-dev
+      - libsoup-gnome2.4-dev
+      - libsoup2.4-dev
+      - libxml2-dev
+      - libxml2-utils
+    stage-packages:
+      - libglib2.0-0
+      - libgtk-3-0
+      - libsoup-gnome2.4-1
+      - libsoup2.4-1
+      - libxml2
+
+# Conflicts, see README.md
+#  mate-icon-theme:
+#    plugin: autotools
+#    source: https://github.com/mate-desktop/mate-icon-theme.git
+#    after: [ mate-common ]
+#    install-via: prefix
+#    build-packages:
+#      - gettext
+#      - hicolor-icon-theme
+#      - icon-naming-utils
+#      - intltool
+#      - librsvg2-bin
+#      - pkg-config
+#    stage-packages:
+#      - hicolor-icon-theme
+#      - libgtk2.0-bin
+#      - librsvg2-common
+
+  mate-system-monitor:
+    plugin: autotools
+    source: https://github.com/mate-desktop/mate-system-monitor.git
+    after: [ mate-common, gtkconf ]
+    configflags:
+      - --disable-schemas-compile
+      - --disable-silent-rules
+      - --libexecdir=/usr/lib/mate-system-monitor
+      - --localstatedir=/var
+      - --disable-static
+      - --enable-systemd
       - --with-gtk=3.0
     install-via: prefix
     build-packages:
+      - docbook-to-man
       - intltool
-      - libgirepository1.0-dev
       - libglib2.0-dev
+      - libglibmm-2.4-dev
       - libgtk-3-dev
-      - libxklavier-dev
+      - libgtkmm-3.0-dev
+      - libgtop2-dev
+      - librsvg2-dev
+      - libsystemd-dev
+      - libwnck-3-dev
+      - libxml2-dev
+      - pkg-config
+      - yelp-tools
     stage-packages:
-      - iso-codes
+      - gvfs
+      - libglib2.0-0
+      - libglibmm-2.4-1v5
+      - libgtk-3-0
+      - libgtkmm-3.0-1v5
+      - libgtop2-common
+      - librsvg2-common
+      - libsystemd0
+      - libwnck-3-0
+      - libxml2
+      - yelp
 
   pluma:
     plugin: autotools
@@ -111,10 +233,10 @@ parts:
     after: [ mate-common, mate-desktop, gtkconf ]
     configflags:
       - --disable-python
+      - --disable-schemas-compile
       - --with-gtk=3.0
     install-via: prefix
     build-packages:
-      - gettext
       - gtk-doc-tools
       - intltool
       - iso-codes
@@ -122,22 +244,32 @@ parts:
       - libglib2.0-dev
       - libgtk-3-dev
       - libgtksourceview-3.0-dev
+      - libsm-dev
+      - libx11-dev
       - libxml2-dev
       - yelp-tools
     stage-packages:
       - dconf-gsettings-backend
       - iso-codes
+      - libenchant1c2a
       - libglib2.0-0
       - libgtk-3-0
+      - libgtksourceview-3.0-1
       - libpango-1.0-0
       - libgdk-pixbuf2.0-0
+      - libsm6
+      - libx11-6
+      - libxml2
+      - yelp
       - zenity
 
   integration:
     plugin: nil
+    after: [ pluma, mate-system-monitor ]
     stage-packages:
       - dmz-cursor-theme
       - light-themes
+      - mate-icon-theme
       - ttf-ubuntu-font-family
       - ubuntu-mate-default-settings
       - ubuntu-mate-icon-themes

--- a/mate-desktop/snapcraft.yaml
+++ b/mate-desktop/snapcraft.yaml
@@ -1,0 +1,147 @@
+name: mate-desktop
+version: 1.15
+summary: MATE Desktop Environment
+description: |
+   The MATE Desktop Environment is the continuation of GNOME 2. It
+   provides an intuitive and attractive desktop environment using traditional
+   metaphors for Linux and other Unix-like operating systems.
+   MATE is under active development to add support for new technologies while
+   preserving a traditional desktop experience.
+confinement: devmode
+
+apps:
+  mate-about:
+    command: gtk-launch mate-about
+    plugs:
+      - home
+      - x11
+
+  pluma:
+    command: gtk-launch pluma
+    plugs:
+      - home
+      - x11
+
+build-packages:
+  - gettext
+  - gtk-doc-tools
+  - intltool
+  - libtool
+  - pkg-config
+
+parts:
+  mate-common:
+    plugin: autotools
+    source: https://github.com/mate-desktop/mate-common.git
+    install-via: prefix
+    build-packages:
+      - gettext
+      - intltool
+      - libtool
+      - pkg-config
+
+  mate-desktop:
+    plugin: autotools
+    source: https://github.com/mate-desktop/mate-desktop.git
+    after: [ mate-common, gtkconf ]
+    configflags:
+      - --disable-mpaste
+      - --disable-schemas-compile
+      - --disable-silent-rules
+      - --disable-static
+      - --with-gtk=3.0
+    install-via: prefix
+    build-packages:
+      - gobject-introspection
+      - gtk-doc-tools
+      - intltool
+      - libdconf-dev
+      - libgirepository1.0-dev
+      - libglib2.0-dev
+      - libglib2.0-doc
+      - libgtk-3-dev
+      - libgtk-3-doc
+      - libstartup-notification0-dev
+      - libxml2-dev
+    stage-packages:
+      - libglib2.0-0
+      - libgtk-3-0
+      - libstartup-notification0
+      - libxml2
+      - hicolor-icon-theme
+
+  mate-user-guide:
+    plugin: autotools
+    source: https://github.com/mate-desktop/mate-user-guide.git
+    after: [ mate-common ]
+    install-via: prefix
+    build-packages:
+      - gettext
+      - gtk-doc-tools
+      - intltool
+      - libtool
+      - pkg-config
+      - libglib2.0-dev
+      - yelp-tools
+    stage-packages:
+      - yelp
+
+  libmatekbd:
+    plugin: autotools
+    source: https://github.com/mate-desktop/libmate.git
+    after: [ mate-common, mate-desktop, gtkconf ]
+    configflags:
+      - --disable-silent-rules
+      - --disable-static
+      - --enable-introspection
+      - --with-gtk=3.0
+    install-via: prefix
+    build-packages:
+      - intltool
+      - libgirepository1.0-dev
+      - libglib2.0-dev
+      - libgtk-3-dev
+      - libxklavier-dev
+    stage-packages:
+      - iso-codes
+
+  pluma:
+    plugin: autotools
+    source: https://github.com/mate-desktop/pluma.git
+    after: [ mate-common, mate-desktop, gtkconf ]
+    configflags:
+      - --disable-python
+      - --with-gtk=3.0
+    install-via: prefix
+    build-packages:
+      - gettext
+      - gtk-doc-tools
+      - intltool
+      - iso-codes
+      - libenchant-dev
+      - libglib2.0-dev
+      - libgtk-3-dev
+      - libgtksourceview-3.0-dev
+      - libxml2-dev
+      - yelp-tools
+    stage-packages:
+      - dconf-gsettings-backend
+      - iso-codes
+      - libglib2.0-0
+      - libgtk-3-0
+      - libpango-1.0-0
+      - libgdk-pixbuf2.0-0
+      - zenity
+
+  integration:
+    plugin: nil
+    stage-packages:
+      - dmz-cursor-theme
+      - light-themes
+      - ttf-ubuntu-font-family
+      - ubuntu-mate-default-settings
+      - ubuntu-mate-icon-themes
+      - ubuntu-mate-themes
+    snap:
+      - usr/share
+      - -usr/share/doc


### PR DESCRIPTION
This is an initial mate-desktop snap. I'm currently stuck with `libmatekbd` which generates the following     error:

    checking for LIBMATE... no
    configure: error: Package requirements ( glib-2.0 >= 2.8.0   gobject-2.0 >= 2.0.0   gmodule-2.0 >=     2.8.0   gobject-2.0 >= 2.8.0   libmatecomponent-2.0 >= 1.1.0    libcanberra >= 0) were not met:
    
    No package 'libmatecomponent-2.0' found
    
    Consider adjusting the PKG_CONFIG_PATH environment variable if you
    installed software in a non-standard prefix.
    
    Alternatively, you may set the environment variables LIBMATE_CFLAGS
    and LIBMATE_LIBS to avoid the need to call pkg-config.
    See the pkg-config man page for more details.
    Command '['/bin/sh', '/tmp/tmptdcqle8i', './configure', '--
    prefix=/home/martin/Development/snaps/mate-
    desktop/parts/libmatekbd/install', '--disable-silent-rules', '--
    disable-static', '--enable-introspection', '--with-gtk=3.0']' returned
    non-zero exit status 1