### PR TITLE
Add podpublish.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This project currently includes the following snaps:
 | :white_check_mark:  | `ristretto`        |                           |
 | :white_check_mark:  | `smplayer`         |                           |
 | :red_circle:        | `plank`            |                           |
+| :white_check_mark:  | `podpublish`       |                           |
 | :white_check_mark:  | `scummvm`          |                           |
 | :white_check_mark:  | `ubuntukylin-icon-theme` |                     |
 | :white_check_mark:  | `tinyproxy`        |                           |

--- a/podpublish/README.md
+++ b/podpublish/README.md
@@ -10,35 +10,15 @@ license.
 
   * https://bitbucket.org/flexiondotorg/podpublish
 
-## Current state
+## Ubuntu Podcast Setup
 
-`podpublish` builds and nearly works. When trying to encode a podcast `ffmpeg` 
-throws the error below, but `libpulsecommon-8.0.so` is in the snap.
+The Snap `home` interface munges `${HOME}` and my use cae for podpublish is to 
+use configuration files that contain relative paths to podcast assets, such as 
+audio files and artwork.
 
-    Traceback (most recent call last):
-      File "/snap/podpublish/x1/usr/bin/encode-podcast", line 9, in <module>
-        load_entry_point('PodPublish==0.0.0', 'console_scripts', 'encode-podcast')()
-      File "/snap/podpublish/x1/usr/lib/python3/dist-packages/PodPublish-0.0.0-py3.5.egg/podpublish/encode_podcast.py", line 20, in main
-        encoder.audio_encode(config, 'mp3')
-      File "/snap/podpublish/x1/usr/lib/python3/dist-packages/PodPublish-0.0.0-py3.5.egg/podpublish/encoder.py", line 36, in audio_encode
-        AudioSegment.from_file(config.audio_in).export(audio_file,
-      File "/snap/podpublish/x1/usr/lib/python3/dist-packages/pydub/audio_segment.py", line 446, in from_file
-        raise CouldntDecodeError("Decoding failed. ffmpeg returned error code: {0}\n\nOutput from ffmpeg/avlib:\n\n{1}".format(p.returncode, p_err))
-    pydub.exceptions.CouldntDecodeError: Decoding failed. ffmpeg returned error code: 127
-    
-    Output from ffmpeg/avlib:
-    
-    b'ffmpeg: error while loading shared libraries: libpulsecommon-8.0.so: cannot open shared object file: No such file or directory\n'
-
-Also, depending on where the show assets are located, some symlinking maybe 
-required.
-
-## Install
-
-The Snap `home` plug doesn't expose the user home directory, just an isolsated 
-data directory. The Ubuntu Podcast team use Dropbox to sync all the show 
-assets, therefore the Dropbox directory needs to be symlinked into the `podpublish`
-snap data directory.
+The Ubuntu Podcast team use Dropbox to sync all the show assets, therefore the 
+Dropbox directory needs to be symlinked into the podpublish snap data 
+directory.
 
 Run the following, which will create the data directory.
 

--- a/podpublish/README.md
+++ b/podpublish/README.md
@@ -1,0 +1,59 @@
+# podpublish
+
+A tool for encoding and publishing podcast content and assets. Inspired
+by [bv-publish](https://github.com/stuartlangridge/bv-publish) and the
+talk [Stuart Langridge gave at Oggcamp 2015](https://www.youtube.com/watch?v=IG6-YdBbwE8).
+
+Project created by [Ubuntu Podcast](http://www.ubuntupodcast.org) and
+released under the [GPLv2](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+license.
+
+  * https://bitbucket.org/flexiondotorg/podpublish
+
+## Current state
+
+`podpublish` builds and nearly works. When trying to encode a podcast `ffmpeg` 
+throws the error below, but `libpulsecommon-8.0.so` is in the snap.
+
+    Traceback (most recent call last):
+      File "/snap/podpublish/x1/usr/bin/encode-podcast", line 9, in <module>
+        load_entry_point('PodPublish==0.0.0', 'console_scripts', 'encode-podcast')()
+      File "/snap/podpublish/x1/usr/lib/python3/dist-packages/PodPublish-0.0.0-py3.5.egg/podpublish/encode_podcast.py", line 20, in main
+        encoder.audio_encode(config, 'mp3')
+      File "/snap/podpublish/x1/usr/lib/python3/dist-packages/PodPublish-0.0.0-py3.5.egg/podpublish/encoder.py", line 36, in audio_encode
+        AudioSegment.from_file(config.audio_in).export(audio_file,
+      File "/snap/podpublish/x1/usr/lib/python3/dist-packages/pydub/audio_segment.py", line 446, in from_file
+        raise CouldntDecodeError("Decoding failed. ffmpeg returned error code: {0}\n\nOutput from ffmpeg/avlib:\n\n{1}".format(p.returncode, p_err))
+    pydub.exceptions.CouldntDecodeError: Decoding failed. ffmpeg returned error code: 127
+    
+    Output from ffmpeg/avlib:
+    
+    b'ffmpeg: error while loading shared libraries: libpulsecommon-8.0.so: cannot open shared object file: No such file or directory\n'
+
+Also, depending on where the show assets are located, some symlinking maybe 
+required.
+
+## Install
+
+The Snap `home` plug doesn't expose the user home directory, just an isolsated 
+data directory. The Ubuntu Podcast team use Dropbox to sync all the show 
+assets, therefore the Dropbox directory needs to be symlinked into the `podpublish`
+snap data directory.
+
+Run the following, which will create the data directory.
+
+    /snap/bin/podpublish.encode-podcast --version
+
+Now symlink Dropbox.
+
+    ln -s ~/Dropbox ~/snap/podpublish/x{*}/
+
+## Use
+
+To encode a podcast.
+
+    /snap/bin/podpublish.encode_podcast ~/Dropbox/UbuntuPodcast/Configs/S09/s09exx.ini
+
+To upload a podcast.
+ 
+    /snap/bin/podpublish.publish_podcast ~/Dropbox/UbuntuPodcast/Configs/S09/s09exx.ini

--- a/podpublish/snapcraft.yaml
+++ b/podpublish/snapcraft.yaml
@@ -1,0 +1,60 @@
+name: podpublish
+version: 20160610+git5ddfa04-1
+summary: A tool for encoding and publishing podcast content and assets
+description: |
+ A tool for encoding and publishing podcast content and assets. Inspired by
+ bv-publish and the talk Stuart Langridge gave at Oggcamp 2015. Project created
+ by Ubuntu Podcast and released under the GPLv2 license.
+
+apps:
+  encode-podcast:
+    command: usr/bin/python3 $SNAP/usr/bin/encode-podcast
+    plugs: [home]
+  publish-podcast:
+    command: usr/bin/python3 $SNAP/usr/bin/publish-podcast
+    plugs: [home, network]
+  season-to-youtube:
+    command: usr/bin/python3 $SNAP/usr/bin/season-to-youtube
+    plugs: [home]
+  youtube-upload:
+    command: usr/bin/python3 $SNAP/usr/bin/youtube-upload
+    plugs: [home, network]
+
+parts:
+  podpublish:
+    plugin: python3
+    source: https://bitbucket.org/flexiondotorg/podpublish.git
+    source-type: git
+    build-packages:
+      - build-essential
+      - liblcms2-dev
+      - libffi-dev
+      - libfreetype6-dev
+      - libjpeg8-dev
+      - libopenjp2-7-dev
+      - libssl-dev
+      - libtiff5-dev
+      - libwebp-dev
+      - pkg-config
+      - zlib1g-dev
+    stage-packages:
+      - ffmpeg
+      - libavcodec-ffmpeg-extra56
+      - liblcms2-2
+      - libffi6
+      - libfreetype6
+      - libjpeg8
+      - libopenjp2-7
+      - libpulse0
+      - libssl1.0.0
+      - libtiff5
+      - libwebp5
+      - zlib1g
+    snap:
+      - -usr/share/bug
+      - -usr/share/doc
+      - -usr/share/doc-base
+      - -usr/share/fonts
+      - -usr/share/include
+      - -usr/share/man
+      - -usr/share/X11/XErrorDB

--- a/podpublish/snapcraft.yaml
+++ b/podpublish/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
  A tool for encoding and publishing podcast content and assets. Inspired by
  bv-publish and the talk Stuart Langridge gave at Oggcamp 2015. Project created
  by Ubuntu Podcast and released under the GPLv2 license.
+confinement: devmode
 
 apps:
   encode-podcast:

--- a/podpublish/snapcraft.yaml
+++ b/podpublish/snapcraft.yaml
@@ -35,12 +35,9 @@ parts:
       - libopenjp2-7-dev
       - libssl-dev
       - libtiff5-dev
-      - libwebp-dev
       - pkg-config
       - zlib1g-dev
     stage-packages:
-      - ffmpeg
-      - libavcodec-ffmpeg-extra56
       - liblcms2-2
       - libffi6
       - libfreetype6
@@ -49,7 +46,6 @@ parts:
       - libpulse0
       - libssl1.0.0
       - libtiff5
-      - libwebp5
       - zlib1g
     snap:
       - -usr/share/bug
@@ -59,3 +55,33 @@ parts:
       - -usr/share/include
       - -usr/share/man
       - -usr/share/X11/XErrorDB
+
+  ffmpeg:
+    source: http://ffmpeg.org/releases/ffmpeg-3.1.1.tar.bz2
+    plugin: autotools
+    configflags: [--enable-gpl, --enable-libass, --enable-libfreetype, --enable-libmp3lame, --enable-libopus, --enable-libtheora, --enable-libvorbis, --enable-libvpx, --enable-libx264, --enable-libx265, --enable-nonfree]
+    build-packages:
+      - yasm
+      - libtool
+      - cmake
+      - pkg-config
+      - build-essential
+      - libass-dev
+      - libfreetype6-dev
+      - libsdl1.2-dev
+      - libtheora-dev
+      - libva-dev
+      - libvdpau-dev
+      - libvorbis-dev
+      - libxcb1-dev
+      - libxcb-shm0-dev
+      - libxcb-xfixes0-dev
+      - texinfo
+      - zlib1g-dev
+      - libx264-dev
+      - libmp3lame-dev
+      - libopus-dev
+      - libx265-dev
+      - libvpx-dev
+    organize:
+      usr/local/bin: usr/bin


### PR DESCRIPTION
This pull request add `podpublish`, a tool for publishing podcasts and their assets.

The snap builds but attempting to encode a podcast causes `ffmpeg` (included via `stage-packages`) to throw an error, see the included README.md for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ubuntu/snappy-playpen/73)
<!-- Reviewable:end -->
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ubuntu/snappy-playpen/pull/73%23issuecomment-227733202%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/73%23issuecomment-227733413%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/73%23discussion_r67680089%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/73%23discussion_r68013835%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/73%23issuecomment-227733202%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%2A%5Bpodpublish/snapcraft.yaml%2C%20line%208%20%5C%5C%5Br2%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/ubuntu/snappy-playpen/73%23-KKs9c_TRK7Uc8JYxm2A%3A-KKs9c_UhBXhfPq2UCEQ%3A-1891975502%29%20%28%5Braw%20file%5D%28https%3A//github.com/ubuntu/snappy-playpen/blob/d8fc05768b16779707c89fd1e312c30014f544ab/podpublish/snapcraft.yaml%23L8%29%29%3A%2A%5Cn%3E%20%60%60%60YAML%5Cn%3E%20%20bv-publish%20and%20the%20talk%20Stuart%20Langridge%20gave%20at%20Oggcamp%202015.%20Project%20created%5Cn%3E%20%20by%20Ubuntu%20Podcast%20and%20released%20under%20the%20GPLv2%20license.%5Cn%3E%20confinement%3A%20devmode%5Cn%3E%20%60%60%60%5Cn%5CnIf%20%60devmode%60%20is%20required%2C%20we%20should%20probably%20note%20this%20down%20in%20%60README.md%60%20somewhere.%5Cn%5Cn---%5Cn%5Cn%5Cn%2AComments%20from%20%5BReviewable%5D%28https%3A//reviewable.io%3A443/reviews/ubuntu/snappy-playpen/73%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-06-22T12%3A52%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%2A%5Bpodpublish/README.md%2C%20line%2042%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/ubuntu/snappy-playpen/73%23-KKmCoRaBBqs2XVowlfx-r1-42%3A-KKs9sklSSmRAZzJw2hy%3A-592478344%29%20%28%5Braw%20file%5D%28https%3A//github.com/ubuntu/snappy-playpen/blob/339f112f52f6b35b06e5636b0a7b799d8c91eefc/podpublish/README.md%23L42%29%29%3A%2A%5Cn%3Cdetails%3E%3Csummary%3E%3Ci%3EPreviously%2C%20flexiondotorg%20%28Martin%20Wimpress%29%20wrote%5Cu2026%3C/i%3E%3C/summary%3E%5Cn%3E%20I%20used%20%60snap%60%202.0.8%20to%20install%20this%20snap%20and%20the%20%60home%60%20interfaces%20were%20automatically%20connected.%20%60snap%20interfaces%60%20confirms%20that%20too.%20I%20can%20access%20files%20in%20%60%7E/snap/podpublish%60.%20The%20symlinking%20in%20%60%7E/snap/podpublish%60%20is%20to%20enable%20access%20to%20file%20I%20want%20podpublish%20to%20process%2C%20and%20works%20fine.%5Cr%3E%20%5Cn%3E%20%5Cr%3E%20%5Cn%3E%20The%20real%20issue%20is%20the%20ffmpeg%20issue%20where%20it%20can%27t%20load%20%60libpulsecommon-8.0.so%60.%5Cn%3C/details%3E%5CnDo%20we%20have%20a%20bug%20for%20this%20issue%20already%3F%5Cn%5Cn---%5Cn%5Cn%5Cn%2AComments%20from%20%5BReviewable%5D%28https%3A//reviewable.io%3A443/reviews/ubuntu/snappy-playpen/73%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-06-22T12%3A52%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20339f112f52f6b35b06e5636b0a7b799d8c91eefc%20podpublish/README.md%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/73%23discussion_r67680089%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Did%20you%20run%20%60snap%20connect%20podpublish%3Ahome%20ubuntu-core%3Ahome%60%3F%22%2C%20%22created_at%22%3A%20%222016-06-20T12%3A21%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20used%20%60snap%60%202.0.8%20to%20install%20this%20snap%20and%20the%20%60home%60%20interfaces%20were%20automatically%20connected.%20%60snap%20interfaces%60%20confirms%20that%20too.%20I%20can%20access%20files%20in%20%60%7E/snap/podpublish%60.%20The%20symlinking%20in%20%60%7E/snap/podpublish%60%20is%20to%20enable%20access%20to%20file%20I%20want%20podpublish%20to%20process%2C%20and%20works%20fine.%5Cr%5Cn%5Cr%5CnThe%20real%20issue%20is%20the%20ffmpeg%20issue%20where%20it%20can%27t%20load%20%60libpulsecommon-8.0.so%60.%22%2C%20%22created_at%22%3A%20%222016-06-22T08%3A34%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/304639%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/flexiondotorg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20podpublish/README.md%3AL1-60%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 339f112f52f6b35b06e5636b0a7b799d8c91eefc podpublish/README.md 42'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/73#discussion_r67680089'>File: podpublish/README.md:L1-60</a></b>
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Did you run `snap connect podpublish:home ubuntu-core:home`?
- <a href='https://github.com/flexiondotorg'><img border=0 src='https://avatars.githubusercontent.com/u/304639?v=3' height=16 width=16'></a> I used `snap` 2.0.8 to install this snap and the `home` interfaces were automatically connected. `snap interfaces` confirms that too. I can access files in `~/snap/podpublish`. The symlinking in `~/snap/podpublish` is to enable access to file I want podpublish to process, and works fine.
The real issue is the ffmpeg issue where it can't load `libpulsecommon-8.0.so`.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/73#issuecomment-227733202'>General Comment</a></b>
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> *[podpublish/snapcraft.yaml, line 8 \[r2\]](https://reviewable.io:443/reviews/ubuntu/snappy-playpen/73#-KKs9c_TRK7Uc8JYxm2A:-KKs9c_UhBXhfPq2UCEQ:-1891975502) ([raw file](https://github.com/ubuntu/snappy-playpen/blob/d8fc05768b16779707c89fd1e312c30014f544ab/podpublish/snapcraft.yaml#L8)):*
> ```YAML
>  bv-publish and the talk Stuart Langridge gave at Oggcamp 2015. Project created
>  by Ubuntu Podcast and released under the GPLv2 license.
> confinement: devmode
> ```
If `devmode` is required, we should probably note this down in `README.md` somewhere.
---
*Comments from [Reviewable](https://reviewable.io:443/reviews/ubuntu/snappy-playpen/73)*
<!-- Sent from Reviewable.io -->
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> *[podpublish/README.md, line 42 \[r1\]](https://reviewable.io:443/reviews/ubuntu/snappy-playpen/73#-KKmCoRaBBqs2XVowlfx-r1-42:-KKs9sklSSmRAZzJw2hy:-592478344) ([raw file](https://github.com/ubuntu/snappy-playpen/blob/339f112f52f6b35b06e5636b0a7b799d8c91eefc/podpublish/README.md#L42)):*
<details><summary><i>Previously, flexiondotorg (Martin Wimpress) wrote…</i></summary>
> I used `snap` 2.0.8 to install this snap and the `home` interfaces were automatically connected. `snap interfaces` confirms that too. I can access files in `~/snap/podpublish`. The symlinking in `~/snap/podpublish` is to enable access to file I want podpublish to process, and works fine.>
> >
> The real issue is the ffmpeg issue where it can't load `libpulsecommon-8.0.so`.
</details>
Do we have a bug for this issue already?
---
*Comments from [Reviewable](https://reviewable.io:443/reviews/ubuntu/snappy-playpen/73)*
<!-- Sent from Reviewable.io -->


<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/73?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/73?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ubuntu/snappy-playpen/pull/73'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>