### PR TITLE
Fix deis workflow cli

### DIFF
--- a/deis-workflow-cli/README.md
+++ b/deis-workflow-cli/README.md
@@ -9,9 +9,5 @@ client has just been released, with not packaging at sight.
 Working features:
  - The snap builds, needs to test in a real server.
 
-Known issues:
- - Without devmode, it gets stuck.
-   Reported in https://bugs.launchpad.net/snappy/+bug/1590221
-
 Unknowns:
  - Many features not tested.

--- a/deis-workflow-cli/snapcraft.yaml
+++ b/deis-workflow-cli/snapcraft.yaml
@@ -4,12 +4,12 @@ summary: The CLI for Deis Workflow
 description: |
   deis is a command line utility used to interact with the Deis open source
   PaaS.
-confinement: devmode
+confinement: strict
 
 apps:
   deis:
     command: bin/workflow-cli
-    plugs: [network]
+    plugs: [network, network-bind]
 
 parts:
   workflow-cli:

--- a/deis-workflow-cli/snapcraft.yaml
+++ b/deis-workflow-cli/snapcraft.yaml
@@ -15,3 +15,4 @@ parts:
   workflow-cli:
     source: https://github.com/deis/workflow-cli.git
     plugin: go
+    go-importpath: github.com/deis/workflow-cli


### PR DESCRIPTION
Fix building with it (as the command now ends up with .git)
Also, we were branching both the branch in `src/` and master in `src/github.com/`. Avoid this double copy which can be problematic, especially if you want to build from a tag.

Finally, add the missing plug to work confined and mark it as such

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ubuntu/snappy-playpen/102)
<!-- Reviewable:end -->
