### PR TITLE
Fix heroku to build with .git extension

### DIFF
--- a/heroku/README.md
+++ b/heroku/README.md
@@ -8,11 +8,7 @@ channels sounds really cool.
 ## Current state
 
 Working features:
- - Login, in devmode
-
-Known issues:
- - Without devmode, it gets stuck.
-   Reported in https://bugs.launchpad.net/snappy/+bug/1590221
+ - Login
 
 Unknowns:
  - It has an update command, that self-updates. I'm not sure how that will work

--- a/heroku/snapcraft.yaml
+++ b/heroku/snapcraft.yaml
@@ -15,3 +15,4 @@ parts:
   heroku-cli:
     source: https://github.com/heroku/cli.git
     plugin: go
+    go-importpath: github.com/heroku/cli

--- a/heroku/snapcraft.yaml
+++ b/heroku/snapcraft.yaml
@@ -5,11 +5,12 @@ description: |
   This is the next generation Go/Node-based Heroku CLI. Currently, it is not
   feature complete with the existing CLI and not intended to be used
   standalone.
+confinement: strict
 
 apps:
   heroku:
     command: bin/cli
-    plugs: [network]
+    plugs: [network, network-bind]
 
 parts:
   heroku-cli:


### PR DESCRIPTION
Use go-import-path to relocate it and ensure we only have one version checked out
Ensure we can run it in strict mode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ubuntu/snappy-playpen/104)
<!-- Reviewable:end -->
