### PR TITLE
Adding menu entry and Desktop Launcher

### DIFF
--- a/wallpaperdownloader/README.md
+++ b/wallpaperdownloader/README.md
@@ -8,10 +8,9 @@ For more information, please visit the official [Wiki](https://bitbucket.org/elo
 
 Working features:
  - The application is working fine. You can even change the downloads folder (by default inside snap directory) to a directory within the user's home folder.
+ - Now, the application is integrated with the Desktop. A Desktop Launcher has been created and a menu entry too under `Utility` category.
 
 Known issues:
   - Open `downloads folder` button is not working. An exception is thrown: 
 
       Error trying to open the Downloads directory. Error: Failed to show URI:file:/home/egarcia/snap/wallpaperdownloader/1/.wallpaperdownloader/downloads/)
-
-  - Icon is defined but it is not integrated with the Desktop.

--- a/wallpaperdownloader/setup/gui/wallpaperdownloader.desktop
+++ b/wallpaperdownloader/setup/gui/wallpaperdownloader.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=2.0
+Name=WallpaperDownloader
+GenericName=Wallpaper Downloader
+Comment=Download and manage wallpapers automatically from the Internet
+Keywords=wallpaper;gallery;internet;download;
+Exec=wallpaperdownloader
+Icon=${SNAP}/meta/gui/icon.png
+Terminal=false
+Type=Application
+Categories=Utility;


### PR DESCRIPTION
Fixing the problem of the Desktop Launcher. Now, it is added and you can launch the application from the Dashboard (GNOME, Unity 8, KDE) or using the main menu. The application has been added to the **Utility** category.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ubuntu/snappy-playpen/131)
<!-- Reviewable:end -->
