### PR TITLE
Shotwell

### DIFF
--- a/shotwell/README.md
+++ b/shotwell/README.md
@@ -3,7 +3,7 @@
 This project creates a working snap of Shotwell from gnome git.
 
 To get this done, we need to do the following:
- - build from current git
+ - build from current git (latest tag)
 
 ## Current state
 
@@ -11,13 +11,9 @@ Working features:
  - Photo import from folder
 
 Known issues:
-  - Only builds with --no-parallel-build
-  - Does not start
-      - If installed without --devmode the program quits with:
-          sh: 0: getcwd() failed: No such file or directory
-          sh: 0: getcwd() failed: No such file or directory
-          shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
-      - If installed with --devmode the program looks for the resources (icons) in the snappy-playpen folder instead of $SNAP
+  - Only builds with --no-parallel-build (fixed in master)
+  - Starts with gtkconf if installed via --devmode
+
 TODO:
   - Fix the need for --devmode
- 
+  - check gtkconf

--- a/shotwell/README.md
+++ b/shotwell/README.md
@@ -11,10 +11,13 @@ Working features:
  - Photo import from folder
 
 Known issues:
-  - Only starts if installed with --devmode.
-    If installed without --devmode the program quits with:
-    /snap/shotwell/x1/bin/gtk-launch: line 111: 142916 Bad system call         cp -a $SNAP/usr/share/mime $XDG_DATA_HOME
-
+  - Only builds with --no-parallel-build
+  - Does not start
+      - If installed without --devmode the program quits with:
+          sh: 0: getcwd() failed: No such file or directory
+          sh: 0: getcwd() failed: No such file or directory
+          shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
+      - If installed with --devmode the program looks for the resources (icons) in the snappy-playpen folder instead of $SNAP
 TODO:
   - Fix the need for --devmode
  

--- a/shotwell/snapcraft.yaml
+++ b/shotwell/snapcraft.yaml
@@ -1,30 +1,29 @@
 name: shotwell
-version: 0.23.1
+version: 0.23.2
 summary: Shotwell photo manager
-description: Shotwell is a photo manager for GNOME 3.
+description: Shotwell is a photo manager for GNOME
 confinement: strict
 
 apps:
   shotwell-git:
-    command: gtk-launch shotwell
+    command: desktop-launch shotwell
     plugs: [x11, unity7, home]
 
 parts:
   shotwell:
     source: git://git.gnome.org/shotwell.git
-    source-tag: shotwell-0.23.1
+    source-tag: shotwell-0.23.2
     plugin: autotools
     build-packages:
-      - debhelper
       - desktop-file-utils
-      - libatk1.0-dev
+      - gnome-doc-utils
       - libexif-dev
       - libgee-0.8-dev
       - libgexiv2-dev
       - libglib2.0-dev
       - libgphoto2-dev
-      - libgstreamer1.0-dev
       - libgstreamer-plugins-base1.0-dev
+      - libgstreamer1.0-dev
       - libgtk-3-dev
       - libgudev-1.0-dev
       - libjson-glib-dev
@@ -32,12 +31,15 @@ parts:
       - librest-dev
       - libsoup2.4-dev
       - libsqlite3-dev
-      - libunity-dev
       - libwebkit2gtk-4.0-dev
       - libxml2
       - m4
       - valac
-      - gnome-doc-utils
+      - libaccounts-glib-dev
+      - libsignon-glib-dev
+      - libunity-dev
+      - python-scour
+      - intltool
     stage-packages:
       - libc6
       - libcairo2
@@ -65,5 +67,4 @@ parts:
       - librsvg2-common
       - dbus-x11
       - dconf-tools
-    after: [gtkconf]
-
+    after: [desktop/gtk3]

--- a/shotwell/snapcraft.yaml
+++ b/shotwell/snapcraft.yaml
@@ -6,7 +6,7 @@ confinement: strict
 
 apps:
   shotwell-git:
-    command: desktop-launch shotwell
+    command: gtk-launch shotwell
     plugs: [x11, unity7, home]
 
 parts:
@@ -40,6 +40,8 @@ parts:
       - libunity-dev
       - python-scour
       - intltool
+      - appstream-util
+      - yelp-tools
     stage-packages:
       - libc6
       - libcairo2
@@ -66,5 +68,5 @@ parts:
       - libxml2
       - librsvg2-common
       - dbus-x11
-      - dconf-tools
-    after: [desktop/gtk3]
+      - dconf-tools 
+    after: [gtkconf]

--- a/shotwell/snapcraft.yaml
+++ b/shotwell/snapcraft.yaml
@@ -1,7 +1,12 @@
 name: shotwell
 version: 0.23.2
 summary: Shotwell photo manager
-description: Shotwell is a photo manager for GNOME
+description: |
+  Shotwell is a digital photo organizer designed for the GNOME desktop
+  environment. It allows you to import photos from disk or camera, organize
+  them in various ways, view them in full-window or fullscreen mode, and
+  export them to share with others. It is able to manage a lot of different
+  image formats, also including raw CR2 files.
 confinement: strict
 
 apps:
@@ -68,5 +73,5 @@ parts:
       - libxml2
       - librsvg2-common
       - dbus-x11
-      - dconf-tools 
+      - dconf-tools
     after: [gtkconf]


### PR DESCRIPTION
Not working. See README

If installed with --devmode it searches for resources in the wrong folder (outside the snap).
If installed without devmode it fails  with an error finding the folder:

```
sh: 0: getcwd() failed: No such file or directory
sh: 0: getcwd() failed: No such file or directory
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ubuntu/snappy-playpen/134)
<!-- Reviewable:end -->
