### PR TITLE
Ristretto to use new launcher and run confined

### DIFF
--- a/ristretto/README.md
+++ b/ristretto/README.md
@@ -12,8 +12,11 @@ Working features:
  - viewing/editing pictures
 
 Known issues:
-  - no thumbnailer service, even though tumbler is included, maybe
-    wrong path?
+  - no thumbnailer service, even though tumbler is included
+** (ristretto:11165): WARNING **: DBUS-call failed:The name
+    org.freedesktop.thumbnails.Thumbnailer1 was not provided by
+    any .service files
+-> no lookup for .service files.
 
 TODO:
  - fix tumbler issue

--- a/ristretto/README.md
+++ b/ristretto/README.md
@@ -3,7 +3,7 @@
 This project creates a working snap of `ristretto`.
 
 To get this done, we need to do the following:
- - use gtk-launch wiki part
+ - use desktop launcher part
  - build from current git
  - run using `--devmode`
 

--- a/ristretto/README.md
+++ b/ristretto/README.md
@@ -5,7 +5,6 @@ This project creates a working snap of `ristretto`.
 To get this done, we need to do the following:
  - use desktop launcher part
  - build from current git
- - run using `--devmode`
 
 ## Current state
 

--- a/ristretto/snapcraft.yaml
+++ b/ristretto/snapcraft.yaml
@@ -4,12 +4,12 @@ summary: lightweight picture-viewer for the Xfce desktop environment
 description: |
   Ristretto is a fast and lightweight picture-viewer for the Xfce desktop
   environment.
-confinement: devmode
+confinement: strict
 
 apps:
   ristretto:
     command: desktop-launch ristretto
-    plugs: [home, network, unity7, x11]
+    plugs: [home, network, unity7, x11, gsettings]
 
 parts:
   ristretto:

--- a/ristretto/snapcraft.yaml
+++ b/ristretto/snapcraft.yaml
@@ -8,7 +8,7 @@ confinement: devmode
 
 apps:
   ristretto:
-    command: gtk-launch ristretto
+    command: desktop-launch ristretto
     plugs: [home, network, unity7, x11]
 
 parts:
@@ -22,16 +22,9 @@ parts:
       - libdbus-glib-1-dev
       - libexif-dev
       - libexo-1-dev
-      - libgtk2.0-dev
       - libxfce4ui-1-dev
       - intltool
       - xfce4-dev-tools
     stage-packages:
-      - fontconfig-config
-      - fonts-freefont-ttf
-      - hicolor-icon-theme
-      - libglib2.0-bin
-      - libgtk2.0-bin
-      - shared-mime-info
       - tumbler
-    after: [gtkconf]
+    after: [desktop/gtk2]


### PR DESCRIPTION
Now, get ristretto to use theme in confined mode.
Update README.md on thumbler service issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ubuntu/snappy-playpen/141)
<!-- Reviewable:end -->
