### PR TITLE
Add the docker-machine snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This project currently includes the following snaps:
 | :white_check_mark:  | `click-parser`     | [click-parser][click-parser] | nodejs                 |
 | :white_check_mark:  | `dcos-cli`         |                           | python3                   |
 | :red_circle:        | `deis-workflow-cli`|                           | go                        |
+| :white_check_mark:  | `docker-machine`   |                           | custom go plugin          |
 | :white_check_mark:  | `dosbox`           |                           | autotools                 |
 | :white_check_mark:  | `ffmpeg`           |                           | autotools                 |
 | :white_check_mark:  | `galculator`       |                           | autotools, gtk3           |

--- a/docker-machine/parts/plugins/x-machine.py
+++ b/docker-machine/parts/plugins/x-machine.py
@@ -1,0 +1,81 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This plugin extends the go plugin to add a bulid path
+
+This plugin uses the common plugin keywords, for more information check the
+'plugins' topic.
+
+This plugin uses the common plugin keywords as well as those for "sources".
+For more information check the 'plugins' topic for the former and the
+'sources' topic for the latter.
+
+Additionally, this plugin uses the following plugin-specific keywords:
+
+    - go-packages:
+      (list of strings)
+      Go packages to fetch, these must be a "main" package. Dependencies
+      are pulled in automatically by `go get`.
+      Packages that are not "main" will not cause an error, but would
+      not be useful either.
+
+    - go-importpath:
+      (string)
+      This entry tells the checked out `source` to live within a certain path
+      within `GOPATH`.
+      This is not needed and does not affect `go-packages`.
+
+    - go-buildpath:
+      (string)
+      This entry is the path of the file to be build and installed.
+"""
+
+import logging
+import os
+
+from snapcraft.plugins import go
+
+
+logger = logging.getLogger(__name__)
+
+
+class MachinePlugin(go.GoPlugin):
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+        schema['properties']['go-buildpath'] = {
+            'type': 'string',
+            'default': ''
+        }
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].extend(['source', 'go-buildpath'])
+
+        return schema
+
+    def _local_build(self):
+        if self.options.go_buildpath:
+            return self._run(
+                ['GOBIN={}'.format(os.path.join(self.installdir, 'bin')),
+                 'go', 'install',
+                 os.path.join(self.sourcedir, self.options.go_buildpath)])
+
+        elif self.options.go_importpath:
+            go_package = self.options.go_importpath
+        else:
+            go_package = os.path.basename(os.path.abspath(self.options.source))
+        self._run(['go', 'install', './{}/...'.format(go_package)])

--- a/docker-machine/snapcraft.yaml
+++ b/docker-machine/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: docker-machine
+version: 0.8.0-rc2
+summary: Machine management for a container-centric world
+description: |
+  Machine lets you create Docker hosts on your computer, on cloud providers,
+  and inside your own data center. It creates servers, installs Docker on them,
+  then configures the Docker client to talk to them.
+confinement: strict
+
+apps:
+  machine:
+    command: bin/machine
+    plugs: [network, network-bind]
+
+parts:
+  machine:
+    plugin: machine
+    source: https://github.com/docker/machine
+    source-type: git
+    source-tag: v0.8.0-rc2
+    go-importpath: github.com/docker/machine
+    go-buildpath: cmd/machine.go
+    build-packages: [g++]


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ubuntu/snappy-playpen/167)

<!-- Reviewable:end -->

<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ubuntu/snappy-playpen/pull/167%23issuecomment-232310478%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/167%23discussion_r70560629%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/167%23discussion_r70641661%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/167%23discussion_r70642590%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/167%23discussion_r70643188%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/167%23discussion_r70644004%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/167%23issuecomment-232310478%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5Cn%5Cn%5CnReviewed%203%20of%203%20files%20at%20r1.%5CnReview%20status%3A%20all%20files%20reviewed%20at%20latest%20revision%2C%201%20unresolved%20discussion.%5Cn%5Cn---%5Cn%5Cn%5Cn%5Cn%2AComments%20from%20%5BReviewable%5D%28https%3A//reviewable.io%3A443/reviews/ubuntu/snappy-playpen/167%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-13T09%3A54%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205a9000fa805d28d117a8dab1b0a9a56f929062ed%20docker-machine/parts/plugins/x-machine.py%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/167%23discussion_r70560629%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40sergiusens%20%40kyrofa%20Any%20better%20ideas%20to%20get%20this%20one%20to%20build%3F%22%2C%20%22created_at%22%3A%20%222016-07-13T03%3A41%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/617831%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elopio%22%7D%7D%2C%20%7B%22body%22%3A%20%22El%2013/07/16%20a%20las%2000%3A41%2C%20Leo%20Arias%20escribi%5Cu00f3%3A%5Cn%3E%5Cn%3E%20In%20docker-machine/parts/plugins/x-machine.py%5Cn%3E%20%3Chttps%3A//github.com/ubuntu/snappy-playpen/pull/167%23discussion_r70560629%3E%3A%5Cn%3E%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20schema%5B%27properties%27%5D%5B%27go-buildpath%27%5D%20%3D%20%7B%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%27type%27%3A%20%27string%27%2C%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%27default%27%3A%20%27%27%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%7D%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%23%20Inform%20Snapcraft%20of%20the%20properties%20associated%20with%20building.%20If%20these%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%23%20change%20in%20the%20YAML%20Snapcraft%20will%20consider%20the%20build%20step%20dirty.%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20schema%5B%27build-properties%27%5D.extend%28%5B%27source%27%2C%20%27go-buildpath%27%5D%29%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20return%20schema%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2B%20%20%20%20def%20_local_build%28self%29%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20if%20self.options.go_buildpath%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20return%20self._run%28%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5B%27GOBIN%3D%7B%7D%27.format%28os.path.join%28self.installdir%2C%20%27bin%27%29%29%2C%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27go%27%2C%20%27install%27%2C%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20os.path.join%28self.sourcedir%2C%20self.options.go_buildpath%29%5D%29%5Cn%3E%5Cn%3E%20%40sergiusens%20%3Chttps%3A//github.com/sergiusens%3E%20%40kyrofa%5Cn%3E%20%3Chttps%3A//github.com/kyrofa%3E%20Any%20better%20ideas%20to%20get%20this%20one%20to%20build%3F%5Cn%3E%5Cn%3E%5Cnpass%20it%20in%20as%20an%20%60env%60%20to%20%60_run%60%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-13T14%3A56%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1146853%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sergiusens%22%7D%7D%2C%20%7B%22body%22%3A%20%22sure%2C%20for%20GOBIN.%20But%20the%20problem%20is%20go-buildpath%3A%20cmd/machine.go%22%2C%20%22created_at%22%3A%20%222016-07-13T15%3A00%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/617831%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elopio%22%7D%7D%2C%20%7B%22body%22%3A%20%22El%2013/07/16%20a%20las%2012%3A01%2C%20Leo%20Arias%20escribi%5Cu00f3%3A%5Cn%3E%5Cn%3E%20In%20docker-machine/parts/plugins/x-machine.py%5Cn%3E%20%3Chttps%3A//github.com/ubuntu/snappy-playpen/pull/167%23discussion_r70642590%3E%3A%5Cn%3E%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20schema%5B%27properties%27%5D%5B%27go-buildpath%27%5D%20%3D%20%7B%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%27type%27%3A%20%27string%27%2C%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%27default%27%3A%20%27%27%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%7D%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%23%20Inform%20Snapcraft%20of%20the%20properties%20associated%20with%20building.%20If%20these%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%23%20change%20in%20the%20YAML%20Snapcraft%20will%20consider%20the%20build%20step%20dirty.%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20schema%5B%27build-properties%27%5D.extend%28%5B%27source%27%2C%20%27go-buildpath%27%5D%29%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20return%20schema%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2B%20%20%20%20def%20_local_build%28self%29%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20if%20self.options.go_buildpath%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20return%20self._run%28%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5B%27GOBIN%3D%7B%7D%27.format%28os.path.join%28self.installdir%2C%20%27bin%27%29%29%2C%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27go%27%2C%20%27install%27%2C%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20os.path.join%28self.sourcedir%2C%20self.options.go_buildpath%29%5D%29%5Cn%3E%5Cn%3E%20sure%2C%20for%20GOBIN.%20But%20the%20problem%20is%20go-buildpath%3A%20cmd/machine.go%5Cn%3E%5Cn%3E%5CnWhere%20does%20go-buildpath%20come%20from%3F%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-13T15%3A03%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1146853%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sergiusens%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20added%20it%20in%20a%20custom%20plugin%20that%20extends%20go.%22%2C%20%22created_at%22%3A%20%222016-07-13T15%3A07%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/617831%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elopio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20docker-machine/parts/plugins/x-machine.py%3AL1-82%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 5a9000fa805d28d117a8dab1b0a9a56f929062ed docker-machine/parts/plugins/x-machine.py 75'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/167#discussion_r70560629'>File: docker-machine/parts/plugins/x-machine.py:L1-82</a></b>
- <a href='https://github.com/elopio'><img border=0 src='https://avatars.githubusercontent.com/u/617831?v=3' height=16 width=16'></a> @sergiusens @kyrofa Any better ideas to get this one to build?
- <a href='https://github.com/sergiusens'><img border=0 src='https://avatars.githubusercontent.com/u/1146853?v=3' height=16 width=16'></a> El 13/07/16 a las 00:41, Leo Arias escribió:
  >
  > In docker-machine/parts/plugins/x-machine.py
  > https://github.com/ubuntu/snappy-playpen/pull/167#discussion_r70560629:
  >
  > > +        schema['properties']['go-buildpath'] = {
  > > +            'type': 'string',
  > > +            'default': ''
  > > +        }
  > > +        # Inform Snapcraft of the properties associated with building. If these
  > > +        # change in the YAML Snapcraft will consider the build step dirty.
  > > +        schema['build-properties'].extend(['source', 'go-buildpath'])
  > > +
  > > +        return schema
  > > +
  > > +    def _local_build(self):
  > > +        if self.options.go_buildpath:
  > > +            return self._run(
  > > +                ['GOBIN={}'.format(os.path.join(self.installdir, 'bin')),
  > > +                 'go', 'install',
  > > +                 os.path.join(self.sourcedir, self.options.go_buildpath)])
  >
  > @sergiusens https://github.com/sergiusens @kyrofa
  > https://github.com/kyrofa Any better ideas to get this one to build?
  >
  >
  pass it in as an `env` to `_run`
- <a href='https://github.com/elopio'><img border=0 src='https://avatars.githubusercontent.com/u/617831?v=3' height=16 width=16'></a> sure, for GOBIN. But the problem is go-buildpath: cmd/machine.go
- <a href='https://github.com/sergiusens'><img border=0 src='https://avatars.githubusercontent.com/u/1146853?v=3' height=16 width=16'></a> El 13/07/16 a las 12:01, Leo Arias escribió:
  >
  > In docker-machine/parts/plugins/x-machine.py
  > https://github.com/ubuntu/snappy-playpen/pull/167#discussion_r70642590:
  >
  > > +        schema['properties']['go-buildpath'] = {
  > > +            'type': 'string',
  > > +            'default': ''
  > > +        }
  > > +        # Inform Snapcraft of the properties associated with building. If these
  > > +        # change in the YAML Snapcraft will consider the build step dirty.
  > > +        schema['build-properties'].extend(['source', 'go-buildpath'])
  > > +
  > > +        return schema
  > > +
  > > +    def _local_build(self):
  > > +        if self.options.go_buildpath:
  > > +            return self._run(
  > > +                ['GOBIN={}'.format(os.path.join(self.installdir, 'bin')),
  > > +                 'go', 'install',
  > > +                 os.path.join(self.sourcedir, self.options.go_buildpath)])
  >
  > sure, for GOBIN. But the problem is go-buildpath: cmd/machine.go
  >
  >
  Where does go-buildpath come from?
- <a href='https://github.com/elopio'><img border=0 src='https://avatars.githubusercontent.com/u/617831?v=3' height=16 width=16'></a> I added it in a custom plugin that extends go.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/167#issuecomment-232310478'>General Comment</a></b>
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Reviewed 3 of 3 files at r1.
  Review status: all files reviewed at latest revision, 1 unresolved discussion.
  ---
  _Comments from [Reviewable](https://reviewable.io:443/reviews/ubuntu/snappy-playpen/167)_
  <!-- Sent from Reviewable.io -->

<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/167?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/167?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ubuntu/snappy-playpen/pull/167'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
