### PR TITLE
Remove devmode error from readme

### DIFF
--- a/residualvm/README.md
+++ b/residualvm/README.md
@@ -12,8 +12,6 @@ Working features:
 
 Known issues:
   - No theme for the main UI
-  - Has to be installed with devmode
 
 TODO:
  - Fix opengl render
- - Fix devmode


### PR DESCRIPTION
Now residualvm works in non devmode
The only issue remaining is the opengl render not working(only nvidia dirver?)
and the theme missing (also in scummvm)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ubuntu/snappy-playpen/180)
<!-- Reviewable:end -->
