### PR TITLE
the build issues with snapcraft 2.12.1 are now fixed

### DIFF
--- a/qownnotes/snapcraft.yaml
+++ b/qownnotes/snapcraft.yaml
@@ -1,16 +1,16 @@
 name: qownnotes
-version: 16.07.3
+version: 16.07.6
 summary: Plain-text file notepad with markdown support and ownCloud integration
 confinement: strict
 description: |
-  QOwnNotes is the open source (GPL) plain-text file notepad with markdown support 
-  and todo list manager for GNU/Linux, Mac OS X and Windows, that (optionally) works 
+  QOwnNotes is the open source (GPL) plain-text file notepad with markdown support
+  and todo list manager for GNU/Linux, Mac OS X and Windows, that (optionally) works
   together with the notes application of ownCloud.
   http://www.qownnotes.org/
 
 apps:
   qownnotes:
-    command: desktop-launch usr/bin/QOwnNotes
+    command: ./wrapper.sh
     plugs:
       - x11
       - network
@@ -19,7 +19,7 @@ apps:
 
 parts:
   qownnotes:
-    source: http://downloads.sourceforge.net/project/qownnotes/src/qownnotes-16.07.3.tar.xz
+    source: http://downloads.sourceforge.net/project/qownnotes/src/qownnotes-16.07.6.tar.xz
     source-type: tar
     plugin: qmake
     qt-version: qt5
@@ -29,6 +29,8 @@ parts:
       - qtdeclarative5-dev
       - libqt5svg5-dev
       - qttools5-dev-tools
+    stage:
+      - -usr/share/pkgconfig
     after: [desktop/qt5]
   env:
     plugin: nil
@@ -43,4 +45,10 @@ parts:
       - libqt5xml5
       - libqt5printsupport5
       - libqt5declarative5
-    after: [qt5conf]
+    stage:
+      - -usr/share/pkgconfig
+    after: [desktop/qt5]
+  launcher:
+    plugin: copy
+    files:
+      wrapper.sh: wrapper.sh

--- a/qownnotes/wrapper.sh
+++ b/qownnotes/wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd $SNAP_USER_DATA
+desktop-launch $SNAP/usr/bin/QOwnNotes "$@"


### PR DESCRIPTION
the build issues with snapcraft 2.12.1 are now fixed, it also builds on https://code.launchpad.net/~pbek/+snap/qownnotes
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-233264367%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-233272616%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-233286710%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-233287779%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-233322917%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-233360083%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-233372805%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-233528631%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-233536578%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234483458%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234484670%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234494363%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234498524%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234498735%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234505534%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234505806%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234507553%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234508225%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234521732%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234522754%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234540037%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-234597100%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/181%23issuecomment-233264367%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%2A%5Bqownnotes/wrapper.sh%2C%20line%204%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/ubuntu/snappy-playpen/181%23-KMx3jio2s2BGD1ItIoE%3A-KMx3jio2s2BGD1ItIoF%3A-191583206%29%20%28%5Braw%20file%5D%28https%3A//github.com/ubuntu/snappy-playpen/blob/88e2882573801722a0412c39e6f3ca1d90748763/qownnotes/wrapper.sh%23L4%29%29%3A%2A%5Cn%3E%20%60%60%60Shell%5Cn%3E%20%5Cn%3E%20cd%20%24SNAP_USER_DATA%5Cn%3E%20desktop-launch%20%24SNAP/usr/bin/QOwnNotes%20%5C%22%24%40%5C%22%5Cn%3E%20%60%60%60%5Cn%5CnCan%20you%20briefly%20explain%20why%20the%20wrapper%20is%20necessary%3F%5Cn%5Cn---%5Cn%5Cn%5Cn%2AComments%20from%20%5BReviewable%5D%28https%3A//reviewable.io%3A443/reviews/ubuntu/snappy-playpen/181%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-18T08%3A15%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20was%20a%20suggestion%20by%20the%20%60ogra%60%20on%20the%20%60snappy%60%20irc%20to%20fix%20the%20%60ln%3A%20failed%20to%20create%20symbolic%20link%20%27/home/omega/snap/qownnotes/7/.themes/themes%27%3A%20Read-only%20file%20system%60%20I%20get%20on%20the%20first%20run%20of%20%60qownnotes%60%20%28do%20you%20get%20that%20too%2C%20%40dholbach%3F%29.%20It%20didn%27t%20fix%20it%20for%20me%20but%20I%20let%20it%20stay%20there%20for%20now.%22%2C%20%22created_at%22%3A%20%222016-07-18T08%3A41%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20see%20the%20issue%20and%20I%27m%20not%20sure%20how%20the%20custom%20launcher%20helps.%5Cn%5Cn---%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%2AComments%20from%20%5BReviewable%5D%28https%3A//reviewable.io%3A443/reviews/ubuntu/snappy-playpen/181%23-%3A-KMxODyJOy4EMDK1TOzW%3A-403148479%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-18T09%3A45%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60%3Cogra%3E%20pbek%2C%20add%3A%20%5C%22cd%20%24SNAP_USER_DATA%5C%22%20to%20your%20launcher%60%20is%20what%20he%20told%20me%20%3B%29%5Cr%5Cn%5Cr%5CnIf%20everything%20works%20in%20the%20end%20with%20native%20theming%20%28and%20maybe%20even%20without%20error%20message%20on%20the%20first%20run%20after%20install/refresh%29%20I%20will%20remove%20the%20launcher%20again.%22%2C%20%22created_at%22%3A%20%222016-07-18T09%3A50%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%2C%20it%20took%20a%20bit%20longer%20to%20figure%20this%20out.%20Here%27s%20what%20works%20for%20me.%20Apply%20this%20diff%20%28http%3A//paste.ubuntu.com/19895620/%29%20on%20top%20of%20current%20master%20and%20you%20get%5Cn%60%60%60%5Cndaniel%40daydream%3A%7E/dev/snappy/snappy-playpen/qownnotes%24%20qownnotes%20%5Cn%5Cn%28process%3A11389%29%3A%20Gtk-WARNING%20%2A%2A%3A%20Locale%20not%20supported%20by%20C%20library.%5Cn%5CtUsing%20the%20fallback%20%27C%27%20locale.%5CnGtk-Message%3A%20Failed%20to%20load%20module%20%5C%22overlay-scrollbar%5C%22%5CnGtk-Message%3A%20Failed%20to%20load%20module%20%5C%22gail%5C%22%5CnGtk-Message%3A%20Failed%20to%20load%20module%20%5C%22atk-bridge%5C%22%5CnGtk-Message%3A%20Failed%20to%20load%20module%20%5C%22unity-gtk-module%5C%22%5CnGtk-Message%3A%20Failed%20to%20load%20module%20%5C%22canberra-gtk-module%5C%22%5CnXmbTextListToTextProperty%20result%20code%20-2%5CnXmbTextListToTextProperty%20result%20code%20-2%5CnXmbTextListToTextProperty%20result%20code%20-2%5CnQSqlQuery%3A%3Aprepare%3A%20database%20not%20open%5CncountAll%20%3A%20%20QSqlError%28%5C%22%5C%22%2C%20%5C%22Driver%20not%20loaded%5C%22%2C%20%5C%22Driver%20not%20loaded%5C%22%29%5CnQSqlQuery%3A%3Aprepare%3A%20database%20not%20open%5Cnstore%20%3A%20%20QSqlError%28%5C%22%5C%22%2C%20%5C%22Driver%20not%20loaded%5C%22%2C%20%5C%22Driver%20not%20loaded%5C%22%29%5CnDebug%3A%20XmbTextListToTextProperty%20result%20code%20-2%5CnDebug%3A%20XmbTextListToTextProperty%20result%20code%20-2%5CnDebug%3A%20XmbTextListToTextProperty%20result%20code%20-2%5CnDebug%3A%20XmbTextListToTextProperty%20result%20code%20-2%5CnDebug%3A%20XmbTextListToTextProperty%20result%20code%20-2%5Cn%5Cn%60%60%60%5Cn%5Cn%21%5BScreenshot%5D%28http%3A//i.imgur.com/MCVW3ZD.png%29%5Cn%5Cn---%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%5Cn%2AComments%20from%20%5BReviewable%5D%28https%3A//reviewable.io%3A443/reviews/ubuntu/snappy-playpen/181%23-%3A-KMy5sAp6I3aE_m44s-8%3A-1171174710%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-18T13%3A07%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dholbach%2C%20I%20tried%20your%20modifications%2C%20but%20I%20still%20don%27t%20get%20KDE%20breeze%20color%20theming%20and%20widgets%20I%20use...%22%2C%20%22created_at%22%3A%20%222016-07-18T15%3A17%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry.%20Can%20you%20maybe%20send%20a%20mail%20to%20the%20snapcraft%20mailing%20list%3F%20I%20personally%20don%27t%20have%20a%20KDE%20Neon%20environment%20to%20test%20it.%22%2C%20%22created_at%22%3A%20%222016-07-18T15%3A58%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20now%20sent%20my%20request%20to%20the%20mailing%20list%2C%20thank%20you.%22%2C%20%22created_at%22%3A%20%222016-07-19T04%3A40%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dholbach%2C%20was%20you%20able%20to%20create%20new%20notes%20in%20your%20installation%3F%20Because%20I%20just%20saw%20that%20I%20can%27t.%20%3A%28%5Cr%5Cn%5Cr%5CnI%20keep%20getting%20%60Permission%20denied%60%20errors...%5Cr%5Cn%28You%20can%20see%20them%20if%20you%20open%20the%20log%20dialog%20in%20the%20window%20menu.%29%22%2C%20%22created_at%22%3A%20%222016-07-19T05%3A35%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20saving%20notes%20works%20for%20me%20with%20the%20patch%20above.%22%2C%20%22created_at%22%3A%20%222016-07-22T08%3A21%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dholbach%2C%20the%20problem%20was%20that%20the%20snap%20home%20directory%20was%20suggested%20as%20home%20directory%20and%20that%20directory%20changes%20for%20every%20revision%20of%20the%20snap.%20And%20the%20next%20revision%20has%20no%20write%20access%20to%20the%20note%20path%20in%20the%20old%20snap%20home%20directory%20%28that%20was%20stored%20in%20the%20settings%29.%20I%20went%20around%20that%20by%20parsing%20the%20correct%20home%20directory%20from%20the%20snap%20home%20directory.%22%2C%20%22created_at%22%3A%20%222016-07-22T08%3A27%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok.%20In%20that%20case%2C%20can%20you%20maybe%20pull%20out%20some%20of%20the%20changes%20of%20my%20patch%2C%20it%20gets%20rid%20of%20one%20of%20the%20%60%5Bdesktop/qt5%5D%60%20mentions%20and%20adds%20%60network-bind%60%2C%20which%20seems%20to%20be%20required.%22%2C%20%22created_at%22%3A%20%222016-07-22T09%3A11%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20is%20what%20I%27m%20currently%20working%20with%3A%20%3Chttps%3A//git.launchpad.net/%7Epbek/qownnotes-snap/tree/snapcraft.yaml%3E%22%2C%20%22created_at%22%3A%20%222016-07-22T09%3A29%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22Although%20I%20still%20have%20the%20problems%20from%20%23145...%22%2C%20%22created_at%22%3A%20%222016-07-22T09%3A30%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22Repository%20%27%257Epbek/qownnotes-snap/tree/snapcraft.yaml%27%20not%20found.%22%2C%20%22created_at%22%3A%20%222016-07-22T10%3A02%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Now%20it%20works.%20Let%20me%20test%20it.%22%2C%20%22created_at%22%3A%20%222016-07-22T10%3A03%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20looks%20like%20it%20works%2C%20even%20picks%20up%20previous%20notes%2C%20but%20my%20%28GTK%29%20theme%20is%20not%20there.%22%2C%20%22created_at%22%3A%20%222016-07-22T10%3A12%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22gtk%20theme%3A%20That%27s%20interesting%2C%20is%20there%20a%20difference%20to%20your%20version%20of%20the%20%60snapcraft.yaml%60%3F%20It%20worked%20with%20your%20version%2C%20didn%27t%20it%3F%22%2C%20%22created_at%22%3A%20%222016-07-22T10%3A15%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20it%20worked%20with%20mine.%22%2C%20%22created_at%22%3A%20%222016-07-22T11%3A34%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22so%20what%27s%20the%20difference%20between%20your%20yaml%20and%20the%20yaml%20from%20the%20repo%20%28beside%20the%20%60--snap%60%20parameter%20and%20the%20new%20version%29%3F%22%2C%20%22created_at%22%3A%20%222016-07-22T11%3A41%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nevermind.%20It%20seems%20to%20work%20now.%20This%20one%20is%20ready%20to%20go%2C%20if%20you%27re%20happy%20with%20it.%22%2C%20%22created_at%22%3A%20%222016-07-22T13%3A12%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20lets%20use%20the%20working%20version.%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-07-22T16%3A55%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/181#issuecomment-233264367'>General Comment</a></b>
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> _[qownnotes/wrapper.sh, line 4 [r1]](https://reviewable.io:443/reviews/ubuntu/snappy-playpen/181#-KMx3jio2s2BGD1ItIoE:-KMx3jio2s2BGD1ItIoF:-191583206) ([raw file](https://github.com/ubuntu/snappy-playpen/blob/88e2882573801722a0412c39e6f3ca1d90748763/qownnotes/wrapper.sh#L4)):_
  > `Shell
  >
  > cd $SNAP_USER_DATA
  > desktop-launch $SNAP/usr/bin/QOwnNotes "$@"
  >`
  Can you briefly explain why the wrapper is necessary?
  ---
  _Comments from [Reviewable](https://reviewable.io:443/reviews/ubuntu/snappy-playpen/181)_
  <!-- Sent from Reviewable.io -->
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> It was a suggestion by the `ogra` on the `snappy` irc to fix the `ln: failed to create symbolic link '/home/omega/snap/qownnotes/7/.themes/themes': Read-only file system` I get on the first run of `qownnotes` (do you get that too, @dholbach?). It didn't fix it for me but I let it stay there for now.
## \- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> I don't see the issue and I'm not sure how the custom launcher helps.

_Comments from [Reviewable](https://reviewable.io:443/reviews/ubuntu/snappy-playpen/181#-:-KMxODyJOy4EMDK1TOzW:-403148479)_

<!-- Sent from Reviewable.io -->
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> `<ogra> pbek, add: "cd $SNAP_USER_DATA" to your launcher` is what he told me ;)
  If everything works in the end with native theming (and maybe even without error message on the first run after install/refresh) I will remove the launcher again.
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Sorry, it took a bit longer to figure this out. Here's what works for me. Apply this diff (http://paste.ubuntu.com/19895620/) on top of current master and you get

```
daniel@daydream:~/dev/snappy/snappy-playpen/qownnotes$ qownnotes
(process:11389): Gtk-WARNING **: Locale not supported by C library.
Using the fallback 'C' locale.
Gtk-Message: Failed to load module "overlay-scrollbar"
Gtk-Message: Failed to load module "gail"
Gtk-Message: Failed to load module "atk-bridge"
Gtk-Message: Failed to load module "unity-gtk-module"
Gtk-Message: Failed to load module "canberra-gtk-module"
XmbTextListToTextProperty result code -2
XmbTextListToTextProperty result code -2
XmbTextListToTextProperty result code -2
QSqlQuery::prepare: database not open
countAll :  QSqlError("", "Driver not loaded", "Driver not loaded")
QSqlQuery::prepare: database not open
store :  QSqlError("", "Driver not loaded", "Driver not loaded")
Debug: XmbTextListToTextProperty result code -2
Debug: XmbTextListToTextProperty result code -2
Debug: XmbTextListToTextProperty result code -2
Debug: XmbTextListToTextProperty result code -2
Debug: XmbTextListToTextProperty result code -2
```
## ![Screenshot](http://i.imgur.com/MCVW3ZD.png)

_Comments from [Reviewable](https://reviewable.io:443/reviews/ubuntu/snappy-playpen/181#-:-KMy5sAp6I3aE_m44s-8:-1171174710)_

<!-- Sent from Reviewable.io -->
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> @dholbach, I tried your modifications, but I still don't get KDE breeze color theming and widgets I use...
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Sorry. Can you maybe send a mail to the snapcraft mailing list? I personally don't have a KDE Neon environment to test it.
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> I now sent my request to the mailing list, thank you.
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> @dholbach, was you able to create new notes in your installation? Because I just saw that I can't. :(
  I keep getting `Permission denied` errors...
  (You can see them if you open the log dialog in the window menu.)
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Yes, saving notes works for me with the patch above.
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> @dholbach, the problem was that the snap home directory was suggested as home directory and that directory changes for every revision of the snap. And the next revision has no write access to the note path in the old snap home directory (that was stored in the settings). I went around that by parsing the correct home directory from the snap home directory.
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Ok. In that case, can you maybe pull out some of the changes of my patch, it gets rid of one of the `[desktop/qt5]` mentions and adds `network-bind`, which seems to be required.
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> That is what I'm currently working with: https://git.launchpad.net/~pbek/qownnotes-snap/tree/snapcraft.yaml
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> Although I still have the problems from #145...
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Repository '%7Epbek/qownnotes-snap/tree/snapcraft.yaml' not found.
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Now it works. Let me test it.
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> It looks like it works, even picks up previous notes, but my (GTK) theme is not there.
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> gtk theme: That's interesting, is there a difference to your version of the `snapcraft.yaml`? It worked with your version, didn't it?
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Yes, it worked with mine.
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> so what's the difference between your yaml and the yaml from the repo (beside the `--snap` parameter and the new version)?
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Nevermind. It seems to work now. This one is ready to go, if you're happy with it.
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> Ok, lets use the working version. :)

<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/181?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/181?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ubuntu/snappy-playpen/pull/181'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
