### PR TITLE
Add docker files for testing the playpen snaps

### DIFF
--- a/ci-run
+++ b/ci-run
@@ -11,9 +11,10 @@ fi
 root_dir=`pwd`
 return_code=0
 for dir in $projects_to_test; do
-    # Don't include files in root and template directory
+    # Don't include files in root, template and testing directories
     [ ! -d $dir ] && continue
     [ "$dir" = "snap-template" ] && continue
+    [ "$dir" = "testing" ] && continue
 
     echo "Testing $dir"
     cd ${root_dir}/$dir

--- a/testing/docker-lts/Dockerfile
+++ b/testing/docker-lts/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:xenial
+
+RUN apt update && apt dist-upgrade -y && apt install -y snapcraft && apt clean
+
+# enable multiverse as snapcraft cleanbuild does.
+RUN sed -i 's/ universe/ universe multiverse/' /etc/apt/sources.list

--- a/testing/docker-lts/README.md
+++ b/testing/docker-lts/README.md
@@ -1,0 +1,3 @@
+# docker-snapcraft
+
+Docker image autobuild for latests snapcraft released on latest ubuntu LTS version.

--- a/testing/docker-master/Dockerfile
+++ b/testing/docker-master/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:xenial
+
+RUN apt update && apt dist-upgrade -y && apt install -y git && apt clean
+
+# enable multiverse as snapcraft cleanbuild does.
+RUN sed -i 's/ universe/ universe multiverse/' /etc/apt/sources.list
+
+# build and install snapcraft from master.
+git clone https://github.com/snapcore/snapcraft
+cd snapcraft
+apt build-dep -y ./
+dpkg-buildpackage -us -uc
+apt install ../*.deb

--- a/testing/docker-master/Dockerfile
+++ b/testing/docker-master/Dockerfile
@@ -1,13 +1,16 @@
 FROM ubuntu:xenial
 
-RUN apt update && apt dist-upgrade -y && apt install -y git && apt clean
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y devscripts equivs git
 
 # enable multiverse as snapcraft cleanbuild does.
 RUN sed -i 's/ universe/ universe multiverse/' /etc/apt/sources.list
 
 # build and install snapcraft from master.
-git clone https://github.com/snapcore/snapcraft
-cd snapcraft
-apt build-dep -y ./
-dpkg-buildpackage -us -uc
-apt install ../*.deb
+RUN git clone https://github.com/snapcore/snapcraft && \
+  cd snapcraft && \
+  mk-build-deps debian/control -i --tool 'apt-get -y' && \
+  dpkg-buildpackage -us -uc && \
+  apt-get install -y ../*.deb && \
+  apt-get clean -y && \
+  apt-get remove --purge -y devscripts equivs git python3-fixtures python3-responses python3-setuptools python3-testscenarios python3-testtools && \
+  apt-get autoremove -y

--- a/testing/docker-master/README.md
+++ b/testing/docker-master/README.md
@@ -1,0 +1,3 @@
+# docker-snapcraft
+
+Docker image autobuild for latests snapcraft master branch on latest ubuntu LTS version.


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23issuecomment-235024252%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23issuecomment-235172657%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23issuecomment-235287831%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23issuecomment-235499274%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23issuecomment-235499345%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23issuecomment-238778458%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23discussion_r72192591%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23discussion_r72262257%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23discussion_r72387325%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23discussion_r74119061%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23discussion_r74192264%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23issuecomment-238778585%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23issuecomment-235024252%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20it%27s%20better%20to%20keep%20all%20the%20resources%20we%20need%20for%20testing%20in%20the%20same%20repository.%5Cr%5CnThe%20docker-lts%20image%20is%20a%20copy%20from%20didrocks%27%20ubuntu/docker-snapcraft.%20The%20other%20one%20is%20for%20testing%20the%20build%20using%20snapcraft%20from%20master.%20%5Cr%5Cn%5Cr%5CnI%20still%20can%27t%20make%20the%20autobuild%20job%20in%20docker%20hub.%20%40didrocks%20could%20you%20do%20it%20for%20me%20or%20give%20me%20more%20permissions%3F%5Cr%5Cn%5Cr%5CnOnce%20the%20autobuild%20is%20ready%2C%20I%20will%20modify%20the%20travis%20file%20to%20get%20the%20image%20name%20as%20an%20argument.%20It%20will%20default%20to%20use%20the%20snapcraft%20in%20xenial%2C%20but%20we%20will%20be%20able%20to%20trigger%20another%20job%20in%20response%20to%20changes%20in%20snapcraft%20that%20uses%20the%20other%20docker%20image.%22%2C%20%22created_at%22%3A%20%222016-07-25T17%3A33%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/617831%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elopio%22%7D%7D%2C%20%7B%22body%22%3A%20%22Excellent%20Leo%21%5Cr%5Cn%5Cr%5CnWe%20did%20the%20autobuild%20with%20a%20webhook%20which%20is%20pushing%20a%20daily%20signal%20to%20tell%20to%20rebuild%20the%20package%20version%20of%20docker.%20For%20the%20one%20from%20master%2C%20I%20guess%2C%20the%20trigger%20is%20from%20any%20new%20commit%20in%20the%20snapcraft%20tree.%20I%27ll%20have%20a%20look%20if%20I%20can%20do%20this%20%28I%27m%20unsure%20if%20docker%20is%20taking%20subdirectories%20though%20for%20those%20use%20case%20or%20expect%20the%20DockerFile%20to%20be%20in%20the%20root%20of%20the%20repo%29.%5Cr%5Cn%5Cr%5CnSomething%20else%3A%20can%20you%20please%20exclude%20the%20%60testing/%60%20directory%20in%20%60ci-run%60%20so%20that%20the%20test%20doesn%27t%20try%20to%20build%20a%20snap%3F%22%2C%20%22created_at%22%3A%20%222016-07-26T06%3A14%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1823296%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/didrocks%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20both%20will%20rebuild%20on%20any%20change%20on%20the%20playpen%2C%20and%20we%20can%20add%20a%20trigger%20from%20changes%20in%20snapcraft%20master%20too.%5Cr%5CnI%20excluded%20the%20testing%20dir.%22%2C%20%22created_at%22%3A%20%222016-07-26T14%3A37%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/617831%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elopio%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20this%20looks%20good%20to%20me%2C%20let%27s%20see%20once%20it%27s%20merged%20how%20you%20can%20create%20a%20couple%20of%20new%20docker%20images%20from%20this%20branch%20%28I%27m%20interested%2C%20I%20didn%27t%20know%20this%20was%20possible%29.%20I%27ll%20let%20you%20handle%20that%20part%20and%20watch%20closely%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-07-27T06%3A35%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1823296%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/didrocks%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-07-27T06%3A35%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1823296%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/didrocks%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-08-10T06%3A37%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1823296%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/didrocks%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%2C%20I%20did%20miss%20the%20followup%20fixes%21%20Everything%20looks%20good%20%28yeah%2C%20let%27s%20do%20that%20for%20build-deps%20for%20now%2C%20good%20enough%21%29.%5Cr%5Cn%5Cr%5CnI%27ll%20let%20you%20setup%20the%20dockerhub%20project%20under%20the%20common%20namespace%20then%21%22%2C%20%22created_at%22%3A%20%222016-08-10T06%3A38%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1823296%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/didrocks%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20087576a7ce6e27954140ffb37de5bcd1e308594a%20testing/docker-master/Dockerfile%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/195%23discussion_r72192591%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20probably%20clean%20the%20build-dep%20in%20the%20image%20after%20building%20the%20package%20to%20keep%20the%20docker%20container%20as%20close%20to%20a%20vanilla%20install%20as%20possible.%22%2C%20%22created_at%22%3A%20%222016-07-26T06%3A11%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1823296%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/didrocks%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20sounds%20great%2C%20but%20I%20don%27t%20know%20how%20to%20do%20it.%20Is%20there%20a%20way%20to%20get%20the%20list%20of%20packages%20that%20will%20be%20installed%20by%20apt%20%3F%20I%20can%27t%20just%20remove%20all%20the%20dependencies%2C%20because%20some%20of%20them%20were%20already%20preinstalled%20in%20the%20machine.%22%2C%20%22created_at%22%3A%20%222016-07-26T14%3A38%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/617831%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elopio%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20unsure%20how%20apt%20build-dep%20works%20%28if%20they%20mark%20the%20deps%20as%20autoinstalled%29.%20If%20so%2C%20you%20can%20just%20run%20%60sudo%20apt%20autoremove%20--purge%60%20once%20you%20installed%20your%20local%20.deb%20%28so%20last%20step%29.%5Cr%5Cn%5Cr%5CnIf%20not%2C%20you%20can%20revert%20to%20the%20old%20way%20of%20doing%20this%20build-dep%20install%3A%5Cr%5Cnhttps%3A//github.com/ubuntu/ubuntu-make/blob/master/Dockerfile%23L53%5Cr%5Cnmk-build-deps%2C%20then%20removing%20the%20local%20.deb%20for%20build-deps%2C%20and%20finally%20apt%20autoclean%20as%20well.%5Cr%5Cn%5Cr%5CnTell%20me%20how%20it%20goes%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-07-27T06%3A38%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1823296%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/didrocks%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40didrocks%20I%20tried%20the%20autoremove%20--purge%2C%20but%20it%20doesn%27t%20remove%20packages%20like%20python3-fixtures%20that%20are%20only%20build%20dependencies.%5Cr%5CnI%20added%20them%20to%20the%20remove%20statement.%20It%20sucks%2C%20because%20it%20can%20get%20out%20of%20date%2C%20but%20works%20for%20now.%20Pushed%20for%20a%20new%20review.%20Thank%20you%21%22%2C%20%22created_at%22%3A%20%222016-08-09T18%3A38%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/617831%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elopio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-08-10T06%3A37%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1823296%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/didrocks%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20testing/docker-master/Dockerfile%3AL1-14%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/didrocks%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1823296%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/didrocks'><img src='https://avatars.githubusercontent.com/u/1823296?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/195#issuecomment-235024252'>General Comment</a></b>
- <a href='https://github.com/elopio'><img border=0 src='https://avatars.githubusercontent.com/u/617831?v=3' height=16 width=16'></a> I think it's better to keep all the resources we need for testing in the same repository.
The docker-lts image is a copy from didrocks' ubuntu/docker-snapcraft. The other one is for testing the build using snapcraft from master.
I still can't make the autobuild job in docker hub. @didrocks could you do it for me or give me more permissions?
Once the autobuild is ready, I will modify the travis file to get the image name as an argument. It will default to use the snapcraft in xenial, but we will be able to trigger another job in response to changes in snapcraft that uses the other docker image.
- <a href='https://github.com/didrocks'><img border=0 src='https://avatars.githubusercontent.com/u/1823296?v=3' height=16 width=16'></a> Excellent Leo!
We did the autobuild with a webhook which is pushing a daily signal to tell to rebuild the package version of docker. For the one from master, I guess, the trigger is from any new commit in the snapcraft tree. I'll have a look if I can do this (I'm unsure if docker is taking subdirectories though for those use case or expect the DockerFile to be in the root of the repo).
Something else: can you please exclude the `testing/` directory in `ci-run` so that the test doesn't try to build a snap?
- <a href='https://github.com/elopio'><img border=0 src='https://avatars.githubusercontent.com/u/617831?v=3' height=16 width=16'></a> I think both will rebuild on any change on the playpen, and we can add a trigger from changes in snapcraft master too.
I excluded the testing dir.
- <a href='https://github.com/didrocks'><img border=0 src='https://avatars.githubusercontent.com/u/1823296?v=3' height=16 width=16'></a> Ok, this looks good to me, let's see once it's merged how you can create a couple of new docker images from this branch (I'm interested, I didn't know this was possible). I'll let you handle that part and watch closely :)
- <a href='https://github.com/didrocks'><img border=0 src='https://avatars.githubusercontent.com/u/1823296?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/didrocks'><img border=0 src='https://avatars.githubusercontent.com/u/1823296?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/didrocks'><img border=0 src='https://avatars.githubusercontent.com/u/1823296?v=3' height=16 width=16'></a> Sorry, I did miss the followup fixes! Everything looks good (yeah, let's do that for build-deps for now, good enough!).
I'll let you setup the dockerhub project under the common namespace then!
- [x] <a href='#crh-comment-Pull 087576a7ce6e27954140ffb37de5bcd1e308594a testing/docker-master/Dockerfile 11'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/195#discussion_r72192591'>File: testing/docker-master/Dockerfile:L1-14</a></b>
- <a href='https://github.com/didrocks'><img border=0 src='https://avatars.githubusercontent.com/u/1823296?v=3' height=16 width=16'></a> I would probably clean the build-dep in the image after building the package to keep the docker container as close to a vanilla install as possible.
- <a href='https://github.com/elopio'><img border=0 src='https://avatars.githubusercontent.com/u/617831?v=3' height=16 width=16'></a> That sounds great, but I don't know how to do it. Is there a way to get the list of packages that will be installed by apt ? I can't just remove all the dependencies, because some of them were already preinstalled in the machine.
- <a href='https://github.com/didrocks'><img border=0 src='https://avatars.githubusercontent.com/u/1823296?v=3' height=16 width=16'></a> I'm unsure how apt build-dep works (if they mark the deps as autoinstalled). If so, you can just run `sudo apt autoremove --purge` once you installed your local .deb (so last step).
If not, you can revert to the old way of doing this build-dep install:
https://github.com/ubuntu/ubuntu-make/blob/master/Dockerfile#L53
mk-build-deps, then removing the local .deb for build-deps, and finally apt autoclean as well.
Tell me how it goes :)
- <a href='https://github.com/elopio'><img border=0 src='https://avatars.githubusercontent.com/u/617831?v=3' height=16 width=16'></a> @didrocks I tried the autoremove --purge, but it doesn't remove packages like python3-fixtures that are only build dependencies.
I added them to the remove statement. It sucks, because it can get out of date, but works for now. Pushed for a new review. Thank you!


<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/195?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/195?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/195?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/ubuntu/snappy-playpen/pull/195'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>