### PR TITLE
Update the vault snap to v0.6.1-rc1. Start the testing.

### DIFF
--- a/vault/README.md
+++ b/vault/README.md
@@ -8,7 +8,7 @@ up-to-date make it a nice use case for snappy.
 ## Current state
 
 Working features:
- - everything
+ - Testing in progress: https://gist.github.com/elopio/e8481471a9b3964ccf5bf9f0c09605a9
 
 Known issues:
  - only uploaded to the store for amd64.

--- a/vault/snapcraft.yaml
+++ b/vault/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: vault-elopio
+name: vault
 version: "0.6.1-rc1"
 summary: Vault is a tool for securely accessing secrets.
 description: |

--- a/vault/snapcraft.yaml
+++ b/vault/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vault-elopio
-version: "0.6.0-rc1"
+version: "0.6.1-rc1"
 summary: Vault is a tool for securely accessing secrets.
 description: |
   A modern system requires access to a multitude of secrets: database
@@ -18,7 +18,7 @@ apps:
 parts:
   vault:
     source: https://github.com/hashicorp/vault.git
-    source-tag: v0.6.0-rc1
+    source-tag: v0.6.1-rc1
     plugin: go
     go-importpath: github.com/hashicorp/vault
     build-packages: [git]

--- a/vault/snapcraft.yaml
+++ b/vault/snapcraft.yaml
@@ -21,4 +21,4 @@ parts:
     source-tag: v0.6.1-rc1
     plugin: go
     go-importpath: github.com/hashicorp/vault
-    build-packages: [git]
+    build-packages: [git, g++, libsasl2-dev]


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ubuntu/snappy-playpen/pull/202%23issuecomment-237442539%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/202%23issuecomment-242500115%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/202%23issuecomment-237442539%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Failing%20because%20snapcraft%20has%20no%20build%20tags%3A%20https%3A//bugs.launchpad.net/snapcraft/%2Bbug/1609623%22%2C%20%22created_at%22%3A%20%222016-08-04T03%3A25%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/617831%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elopio%22%7D%7D%2C%20%7B%22body%22%3A%20%22Vault%20is%20not%20using%20go%201.7%2C%20which%20we%20have%20nowhere%20yet.%20https%3A//bugs.launchpad.net/snapcraft/%2Bbug/1616985%22%2C%20%22created_at%22%3A%20%222016-08-25T18%3A55%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/617831%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elopio%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/202#issuecomment-237442539'>General Comment</a></b>
- <a href='https://github.com/elopio'><img border=0 src='https://avatars.githubusercontent.com/u/617831?v=3' height=16 width=16'></a> Failing because snapcraft has no build tags: https://bugs.launchpad.net/snapcraft/+bug/1609623
- <a href='https://github.com/elopio'><img border=0 src='https://avatars.githubusercontent.com/u/617831?v=3' height=16 width=16'></a> Vault is not using go 1.7, which we have nowhere yet. https://bugs.launchpad.net/snapcraft/+bug/1616985

<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/202?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/202?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ubuntu/snappy-playpen/pull/202'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
