### PR TITLE
Add Cuberite - A performant Mincraft server written in C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project currently includes the following snaps:
 | :white_check_mark:  | `cloudfoundry-cli` |                           | go                        |
 | :white_check_mark:  | `consul`           |                           | go                        |
 | :white_check_mark:  | `click-parser`     | [click-parser][click-parser] | nodejs                 |
+| :white_check_mark:  | `cuberite    `     |                           | cmake                     |
 | :white_check_mark:  | `dcos-cli`         |                           | python3                   |
 | :red_circle:        | `deis-workflow-cli`|                           | go                        |
 | :white_check_mark:  | `dosbox`           |                           | autotools                 |

--- a/cuberite/Cuberite.wrapper
+++ b/cuberite/Cuberite.wrapper
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+for file in brewing.txt crafting.txt favicon.png furnace.txt items.ini monsters.ini README.txt; do
+    if [ ! -f "$SNAP_USER_DATA/$file" ]; then
+        cp --preserve=mode "$SNAP/$file" "$SNAP_USER_DATA"
+    fi
+done
+
+for dir in lang Plugins Prefabs webadmin; do
+    if [ ! -d "$SNAP_USER_DATA/$dir" ]; then
+        cp -r --preserve=mode "$SNAP/$dir" "$SNAP_USER_DATA"
+    fi
+done
+
+cd "$SNAP_USER_DATA"
+exec "$SNAP"/Cuberite -d

--- a/cuberite/README.md
+++ b/cuberite/README.md
@@ -1,0 +1,25 @@
+# Cuberite snap
+
+This project creates a working snap of Cuberite from upstream git.
+
+To get this done, we need to do the following:
+ - build from current tip of git.
+ - stage the Server directory from the source tree.
+ - Add a wrapper to copy runtime files to a writable directory and launch the
+   server from there.
+
+## Current state
+
+Working features:
+ - Game tested with Minecraft 1.9 client.
+ - Web Admin.
+ - Plugins.
+
+Known issues:
+  - Still needs devmode thanks to a call to fchown in the statically-linked
+    sqlite3.
+
+TODO:
+ - Since Cuberite uses the current working directory for its data, it'd be
+   great to be able to manage several instances easily.
+ 

--- a/cuberite/snapcraft.yaml
+++ b/cuberite/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
     Cuberite can run on Windows, *nix and Android operating systems. This includes Android phones and tablets as well as Raspberry Pis.
 
     We currently support Release 1.8 and 1.9 Minecraft protocol versions.
-confinement: devmode
+confinement: strict
 
 apps:
     cuberite:
@@ -28,6 +28,9 @@ parts:
         build-packages:
             - gcc
             - g++
+        snap:
+            - -include
+            - -lib
     release:
         after: [cuberite]
         plugin: copy

--- a/cuberite/snapcraft.yaml
+++ b/cuberite/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cuberite
-version: 20160729
+version: 20160804
 summary: Performant open source Minecraft server written in C++.
 description: |
     Cuberite is a Minecraft-compatible multiplayer game server that is written in C++ and designed to be efficient with memory and CPU, as well as having a flexible Lua Plugin API. Cuberite is compatible with the vanilla Minecraft client.
@@ -24,7 +24,7 @@ parts:
         source: https://github.com/cuberite/cuberite.git
         configflags:
             - -DCMAKE_BUILD_TYPE=Release
-            - -DCROSSCOMPILE=ON
+            - -DNO_NATIVE_OPTIMIZATION=ON
         build-packages:
             - gcc
             - g++

--- a/cuberite/snapcraft.yaml
+++ b/cuberite/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: cuberite
+version: 0  # the version of the snap
+summary: Performant open source Minecraft server written in C++.
+description: This is my-snap's description  # a longer description for the snap
+confinement: strict
+
+apps:
+    cuberite:
+        command: bin/Cuberite.wrapper
+        daemon: forking
+        plugs:
+            - network
+            - network-bind
+            - log-observe
+
+parts:
+    cuberite:
+        plugin: cmake
+        source: https://github.com/cuberite/cuberite.git
+        configflags:
+            - -DCMAKE_BUILD_TYPE=Release
+            - -DCROSSCOMPILE=ON
+        build-packages:
+            - gcc
+            - g++
+    release:
+        after: [cuberite]
+        plugin: copy
+        source: parts/cuberite/src/Server
+        files:
+            "*": "."
+    wrapper:
+        plugin: copy
+        source: .
+        files:
+            Cuberite.wrapper: bin/Cuberite.wrapper

--- a/cuberite/snapcraft.yaml
+++ b/cuberite/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
     Cuberite can run on Windows, *nix and Android operating systems. This includes Android phones and tablets as well as Raspberry Pis.
 
     We currently support Release 1.8 and 1.9 Minecraft protocol versions.
-confinement: strict
+confinement: devmode
 
 apps:
     cuberite:

--- a/cuberite/snapcraft.yaml
+++ b/cuberite/snapcraft.yaml
@@ -1,7 +1,12 @@
 name: cuberite
-version: 0  # the version of the snap
+version: 20160729
 summary: Performant open source Minecraft server written in C++.
-description: This is my-snap's description  # a longer description for the snap
+description: |
+    Cuberite is a Minecraft-compatible multiplayer game server that is written in C++ and designed to be efficient with memory and CPU, as well as having a flexible Lua Plugin API. Cuberite is compatible with the vanilla Minecraft client.
+
+    Cuberite can run on Windows, *nix and Android operating systems. This includes Android phones and tablets as well as Raspberry Pis.
+
+    We currently support Release 1.8 and 1.9 Minecraft protocol versions.
 confinement: strict
 
 apps:


### PR DESCRIPTION
This branch adds Cuberite as a subproject.  Cuberite is a Minecraft server written in C++ and released under the terms of the Apache 2.0 license.

This recipe builds Cuberite from git HEAD and adds a wrapper to set up the working directory before spawning the server. Cuberite is relocatable and uses the current working directory for its data, so multiple instances can be run on the same server. A possible improvement to the packaging would be to enable this via the system start-up scripts, something akin to the old `network-interface` or `lxc-instance` upstart scripts, or the current `lxc-containers` systemd unit

Currently requires devmode due to a call to `fchown` in the statically-linked sqlite: when running confined the process gets killed and I end up with `Cuberite <defunct>` in the process list, and Cuberite will not TCP ACK incoming TCP SYN packets.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23issuecomment-238158124%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23issuecomment-238411210%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23issuecomment-238506142%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23issuecomment-238506266%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23discussion_r74005249%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23discussion_r74005271%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23discussion_r74019441%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23discussion_r74021935%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23discussion_r74027576%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23discussion_r74029007%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23discussion_r74029046%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23issuecomment-238158124%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Nice%20work%2C%20do%20you%20you%20think%20you%20can%20update%20%60README.md%60%20in%20the%20top-level%20directory%20and%20add%20a%20README.md%20in%20this%20directory%20based%20on%20%60./snap-template/README.md%60%3F%22%2C%20%22created_at%22%3A%20%222016-08-08T07%3A11%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20and%20done.%20Also%20stripped%20out%20a%20couple%20of%20unnecessary%20directories.%22%2C%20%22created_at%22%3A%20%222016-08-08T23%3A42%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1237300%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jamestait%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-08-09T09%3A48%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-08-09T09%3A49%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208ab95c7c3db59ddcc7e627a3a527c255afcadf4b%20cuberite/snapcraft.yaml%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23discussion_r74005271%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Are%20these%20header%20files%20being%20shipped%3F%22%2C%20%22created_at%22%3A%20%222016-08-09T06%3A44%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22These%20are%20the%20libjsoncpp%20headers%2C%20which%20are%20the%20only%20thing%20that%20gets%20installed%20through%20%60make%20install%60.%20So%20they%20shouldn%27t%20be%20shipped%20as%20part%20of%20the%20package.%22%2C%20%22created_at%22%3A%20%222016-08-09T09%3A38%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1237300%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jamestait%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-08-09T09%3A48%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20cuberite/snapcraft.yaml%3AL28-37%22%7D%2C%20%22Pull%208ab95c7c3db59ddcc7e627a3a527c255afcadf4b%20cuberite/README.md%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/203%23discussion_r74005249%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20PR%20seems%20to%20change%20things%20from%20%60devmode%60%20to%20%60strict%60%20though...%22%2C%20%22created_at%22%3A%20%222016-08-09T06%3A43%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22On%20Tuesday%2C%209%20August%202016%2007%3A44%3A00%20BST%2C%20Daniel%20Holbach%20%5Cn%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%3E%3E%20%2B%20-%20build%20from%20current%20tip%20of%20git.%5Cn%3E%3E%20%2B%20-%20stage%20the%20Server%20directory%20from%20the%20source%20tree.%5Cn%3E%3E%20%2B%20-%20Add%20a%20wrapper%20to%20copy%20runtime%20files%20to%20a%20writable%20%5Cn%3E%3E%20directory%20and%20launch%20the%5Cn%3E%3E%20%2B%20%20%20server%20from%20there.%5Cn%3E%3E%20%2B%5Cn%3E%3E%20%2B%23%23%20Current%20state%5Cn%3E%3E%20%2B%5Cn%3E%3E%20%2BWorking%20features%3A%5Cn%3E%3E%20%2B%20-%20Game%20tested%20with%20Minecraft%201.9%20client.%5Cn%3E%3E%20%2B%20-%20Web%20Admin.%5Cn%3E%3E%20%2B%20-%20Plugins.%5Cn%3E%3E%20%2B%5Cn%3E%3E%20%2BKnown%20issues%3A%5Cn%3E%3E%20%2B%20%20-%20Still%20needs%20devmode%20thanks%20to%20a%20call%20to%20fchown%20in%20the%20%5Cn%3E%3E%20statically-linked%5Cn%3E%3E%20%2B%20%20%20%20sqlite3.%5Cn%3E%3E%20%2B%5Cn%3E%20%5Cn%3E%20This%20PR%20seems%20to%20change%20things%20from%20%60devmode%60%20to%20%60strict%60%20though...%5Cn%5CnArgh%21%20Good%20catch%2C%20thanks.%20The%20devmode%20is%20still%20required%2C%20I%20was%20testing%20it%20%5Cnin%20strict%20and%20must%20have%20forgotten%20to%20change%20it%20back.%5Cn%5Cn%5Cn--%20%5CnSent%20using%20Dekko%20from%20my%20Ubuntu%20device%5Cn%22%2C%20%22created_at%22%3A%20%222016-08-09T08%3A40%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1237300%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jamestait%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%20you%20update%20it%3F%22%2C%20%22created_at%22%3A%20%222016-08-09T08%3A57%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-08-09T09%3A49%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20cuberite/README.md%3AL1-26%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/dholbach%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/dholbach'><img src='https://avatars.githubusercontent.com/u/1346979?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/203#issuecomment-238158124'>General Comment</a></b>
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Nice work, do you you think you can update `README.md` in the top-level directory and add a README.md in this directory based on `./snap-template/README.md`?
- <a href='https://github.com/jamestait'><img border=0 src='https://avatars.githubusercontent.com/u/1237300?v=3' height=16 width=16'></a> Done and done. Also stripped out a couple of unnecessary directories.
- [x] <a href='#crh-comment-Pull 8ab95c7c3db59ddcc7e627a3a527c255afcadf4b cuberite/README.md 21'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/203#discussion_r74005249'>File: cuberite/README.md:L1-26</a></b>
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> This PR seems to change things from `devmode` to `strict` though...
- <a href='https://github.com/jamestait'><img border=0 src='https://avatars.githubusercontent.com/u/1237300?v=3' height=16 width=16'></a> On Tuesday, 9 August 2016 07:44:00 BST, Daniel Holbach
<notifications@github.com> wrote:
>> + - build from current tip of git.
>> + - stage the Server directory from the source tree.
>> + - Add a wrapper to copy runtime files to a writable
>> directory and launch the
>> +   server from there.
>> +
>> +## Current state
>> +
>> +Working features:
>> + - Game tested with Minecraft 1.9 client.
>> + - Web Admin.
>> + - Plugins.
>> +
>> +Known issues:
>> +  - Still needs devmode thanks to a call to fchown in the
>> statically-linked
>> +    sqlite3.
>> +
>
> This PR seems to change things from `devmode` to `strict` though...
Argh! Good catch, thanks. The devmode is still required, I was testing it
in strict and must have forgotten to change it back.
--
Sent using Dekko from my Ubuntu device
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Can you update it?
- [x] <a href='#crh-comment-Pull 8ab95c7c3db59ddcc7e627a3a527c255afcadf4b cuberite/snapcraft.yaml 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/203#discussion_r74005271'>File: cuberite/snapcraft.yaml:L28-37</a></b>
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Are these header files being shipped?
- <a href='https://github.com/jamestait'><img border=0 src='https://avatars.githubusercontent.com/u/1237300?v=3' height=16 width=16'></a> These are the libjsoncpp headers, which are the only thing that gets installed through `make install`. So they shouldn't be shipped as part of the package.


<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/203?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/203?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/203?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/ubuntu/snappy-playpen/pull/203'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>