### PR TITLE
use dump plugin instead of copy plugin, as it gets into deprecation mode with snapcraft 2.14 onwards

### DIFF
--- a/jtiledownloader/snapcraft.yaml
+++ b/jtiledownloader/snapcraft.yaml
@@ -13,12 +13,11 @@ apps:
 
 parts:
     jtiledownloader:
-        plugin: copy
+        plugin: dump
         source:  http://svn.openstreetmap.org/applications/utils/downloading/JTileDownloader/trunk/release/jTileDownloader-0-6-1.zip
-        files:
-            "*": .
         stage-packages: [gtk2-engines-murrine, light-themes, openjdk-8-jre]
     launcher:
-        plugin: copy
-        files:
+        plugin: dump
+        source: .
+        organize:
             launcher: bin/launcher

--- a/jtiledownloader/snapcraft.yaml
+++ b/jtiledownloader/snapcraft.yaml
@@ -13,11 +13,11 @@ apps:
 
 parts:
     jtiledownloader:
-        plugin: dump
         source:  http://svn.openstreetmap.org/applications/utils/downloading/JTileDownloader/trunk/release/jTileDownloader-0-6-1.zip
+        plugin: dump
         stage-packages: [gtk2-engines-murrine, light-themes, openjdk-8-jre]
     launcher:
-        plugin: dump
         source: .
+        plugin: dump
         organize:
             launcher: bin/launcher

--- a/kodi-stable/snapcraft.yaml
+++ b/kodi-stable/snapcraft.yaml
@@ -212,7 +212,8 @@ parts:
     stage-packages:
       - libc6
   wrappers-copy:
-    plugin: copy
-    files:
+    plugin: dump
+    source: .
+    organize:
       wrapper_kodi.sh: bin/wrapper_kodi.sh
       wrapper_kodi-standalone.sh: bin/wrapper_kodi-standalone.sh

--- a/kodi-stable/snapcraft.yaml
+++ b/kodi-stable/snapcraft.yaml
@@ -212,8 +212,8 @@ parts:
     stage-packages:
       - libc6
   wrappers-copy:
-    plugin: dump
     source: .
+    plugin: dump
     organize:
       wrapper_kodi.sh: bin/wrapper_kodi.sh
       wrapper_kodi-standalone.sh: bin/wrapper_kodi-standalone.sh

--- a/kpcli/snapcraft.yaml
+++ b/kpcli/snapcraft.yaml
@@ -13,8 +13,8 @@ apps:
 parts:
   kpcli:
     source: https://github.com/alecsammon/kpcli.git
-    plugin: copy
-    files:
+    plugin: dump
+    organize:
       kpcli.pl: scripts/kpcli.pl
     stage-packages:
       - perl-base
@@ -26,6 +26,7 @@ parts:
       - libterm-readline-gnu-perl
       - libclone-perl
   launcher:
-    plugin: copy
-    files:
+    plugin: dump
+    source: .
+    organize:
       run.sh: scripts/run.sh

--- a/minetest/snapcraft.yaml
+++ b/minetest/snapcraft.yaml
@@ -15,13 +15,14 @@ apps:
 
 parts:
   launcher:
-    plugin: copy
-    files:
+    plugin: dump
+    source: .
+    organize:
       minetest: minetest
   minetestgame:
     source: https://github.com/minetest/minetest_game.git
-    plugin: copy
-    files:
+    plugin: dump
+    organize:
       '*': 'games/minetest_game/'
   minetest:
     source: https://github.com/minetest/minetest.git

--- a/minetest/snapcraft.yaml
+++ b/minetest/snapcraft.yaml
@@ -15,8 +15,8 @@ apps:
 
 parts:
   launcher:
-    plugin: dump
     source: .
+    plugin: dump
     organize:
       minetest: minetest
   minetestgame:

--- a/minetest/snapcraft.yaml
+++ b/minetest/snapcraft.yaml
@@ -16,13 +16,13 @@ apps:
 parts:
   launcher:
     source: .
-    plugin: dump
-    organize:
+    plugin: copy
+    files:
       minetest: minetest
   minetestgame:
     source: https://github.com/minetest/minetest_game.git
-    plugin: dump
-    organize:
+    plugin: copy
+    files:
       '*': 'games/minetest_game/'
   minetest:
     source: https://github.com/minetest/minetest.git

--- a/mpv/snapcraft.yaml
+++ b/mpv/snapcraft.yaml
@@ -14,6 +14,7 @@ description: |
   * Wayland support 
   * Support for playing URLs of popular streaming sites
   * Screenshot improvements
+confinement: strict
 
 apps:
   mpv:
@@ -22,8 +23,9 @@ apps:
 
 parts:
   launcher:
-    plugin: copy
-    files:
+    plugin: dump
+    source: .
+    organize:
       mpv: bin/mpv
   ffmpeg:
     source: git://source.ffmpeg.org/ffmpeg.git

--- a/mpv/snapcraft.yaml
+++ b/mpv/snapcraft.yaml
@@ -23,8 +23,8 @@ apps:
 
 parts:
   launcher:
-    plugin: dump
     source: .
+    plugin: dump
     organize:
       mpv: bin/mpv
   ffmpeg:

--- a/openjdk-demo/snapcraft.yaml
+++ b/openjdk-demo/snapcraft.yaml
@@ -11,7 +11,8 @@ apps:
 
 parts:
   openjdk-demo:
-    plugin: copy
-    files:
+    plugin: dump
+    source: .
+    organize:
       FileChooserDemo.sh: bin/FileChooserDemo.sh
     stage-packages: [openjdk-8-jre, openjdk-8-demo]

--- a/openjdk-demo/snapcraft.yaml
+++ b/openjdk-demo/snapcraft.yaml
@@ -11,8 +11,8 @@ apps:
 
 parts:
   openjdk-demo:
-    plugin: dump
     source: .
+    plugin: dump
     organize:
       FileChooserDemo.sh: bin/FileChooserDemo.sh
     stage-packages: [openjdk-8-jre, openjdk-8-demo]

--- a/openttd/snapcraft.yaml
+++ b/openttd/snapcraft.yaml
@@ -20,12 +20,5 @@ apps:
 parts:
   openttd:
     source: http://binaries.openttd.org/releases/1.6.1/openttd-1.6.1-linux-generic-amd64.tar.gz
-<<<<<<< HEAD
-    plugin: copy
-    files:
-      '*': './'
-    after: [desktop-qt5]
-=======
     plugin: dump
     after: [desktop/qt5]
->>>>>>> 8f6657b... use dump plugin instead of copy plugin, as it gets into deprecation mode with snapcraft 2.14 onwards

--- a/openttd/snapcraft.yaml
+++ b/openttd/snapcraft.yaml
@@ -20,7 +20,12 @@ apps:
 parts:
   openttd:
     source: http://binaries.openttd.org/releases/1.6.1/openttd-1.6.1-linux-generic-amd64.tar.gz
+<<<<<<< HEAD
     plugin: copy
     files:
       '*': './'
     after: [desktop-qt5]
+=======
+    plugin: dump
+    after: [desktop/qt5]
+>>>>>>> 8f6657b... use dump plugin instead of copy plugin, as it gets into deprecation mode with snapcraft 2.14 onwards

--- a/plank/snapcraft.yaml
+++ b/plank/snapcraft.yaml
@@ -39,7 +39,8 @@ parts:
         - libwnck-3-0
         - libbamf3-2
   launcher:
-    plugin: copy
-    files:
+    plugin: dump
+    source: .
+    organize:
       launcher: bin/plank.run
 

--- a/plank/snapcraft.yaml
+++ b/plank/snapcraft.yaml
@@ -39,8 +39,8 @@ parts:
         - libwnck-3-0
         - libbamf3-2
   launcher:
-    plugin: dump
     source: .
+    plugin: dump
     organize:
       launcher: bin/plank.run
 

--- a/tinyproxy/snapcraft.yaml
+++ b/tinyproxy/snapcraft.yaml
@@ -11,10 +11,7 @@ apps:
     plugs: [network, network-bind]
 
 parts:
-  server:
-    plugin: nil
+  tinyproxy:
+    plugin: dump
+    source: .
     stage-packages: [tinyproxy]
-  glue:
-    plugin: copy
-    files:
-      launcher.sh: launcher.sh

--- a/tinyproxy/snapcraft.yaml
+++ b/tinyproxy/snapcraft.yaml
@@ -12,6 +12,6 @@ apps:
 
 parts:
   tinyproxy:
-    plugin: dump
     source: .
+    plugin: dump
     stage-packages: [tinyproxy]

--- a/ubuntu-clock-app/snapcraft.yaml
+++ b/ubuntu-clock-app/snapcraft.yaml
@@ -44,7 +44,8 @@ parts:
       - -usr/share/doc
       - -usr/include
   environment:
-    plugin: copy
-    files:
+    plugin: dump
+    source: .
+    organize:
       clock.wrapper: bin/clock
       snappy-qt5.conf: etc/xdg/qtchooser/snappy-qt5.conf

--- a/ubuntu-clock-app/snapcraft.yaml
+++ b/ubuntu-clock-app/snapcraft.yaml
@@ -44,8 +44,8 @@ parts:
       - -usr/share/doc
       - -usr/include
   environment:
-    plugin: dump
     source: .
+    plugin: dump
     organize:
       clock.wrapper: bin/clock
       snappy-qt5.conf: etc/xdg/qtchooser/snappy-qt5.conf

--- a/wallpaperdownloader/snapcraft.yaml
+++ b/wallpaperdownloader/snapcraft.yaml
@@ -19,6 +19,7 @@ parts:
   # This script contains all the commands needed (sets env variables, launches the jar file...) to
   # execute the application
   exec:
-    plugin: copy
-    files:
+    plugin: dump
+    source: .
+    organize:
       wallpaperdownloader.sh: bin/wallpaperdownloader.sh

--- a/wallpaperdownloader/snapcraft.yaml
+++ b/wallpaperdownloader/snapcraft.yaml
@@ -12,14 +12,14 @@ apps:
 parts:
   # Pulls the code from the original source (master branch)
   wallpaperdownloader:
-    plugin: maven
     source: https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader.git
+    plugin: maven
 
   # It will copy wallpaperdownloader script into /bin/
   # This script contains all the commands needed (sets env variables, launches the jar file...) to
   # execute the application
   exec:
-    plugin: dump
     source: .
+    plugin: dump
     organize:
       wallpaperdownloader.sh: bin/wallpaperdownloader.sh


### PR DESCRIPTION
This doesn't convert ALL snaps to the `dump` plugin because some don't build right now. Issues are filed.