### PR TITLE
fixed the Exec path

### DIFF
--- a/qownnotes/setup/gui/QOwnNotes.desktop
+++ b/qownnotes/setup/gui/QOwnNotes.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=QOwnNotes
 Comment=Plain text notepad and todo list manager with markdown support that works together with ownCloud
-Exec=usr/bin/QOwnNotes
+Exec=qownnotes
 Icon=${SNAP}/meta/gui/QOwnNotes.png
 Type=Application
 Terminal=false

--- a/qownnotes/setup/gui/QOwnNotes.desktop
+++ b/qownnotes/setup/gui/QOwnNotes.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=QOwnNotes
 Comment=Plain text notepad and todo list manager with markdown support that works together with ownCloud
-Exec=qownnotes
+Exec=${SNAP}/qownnotes
 Icon=${SNAP}/meta/gui/QOwnNotes.png
 Type=Application
 Terminal=false

--- a/qownnotes/setup/gui/QOwnNotes.desktop
+++ b/qownnotes/setup/gui/QOwnNotes.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=QOwnNotes
 Comment=Plain text notepad and todo list manager with markdown support that works together with ownCloud
-Exec=${SNAP}/qownnotes
+Exec=qownnotes
 Icon=${SNAP}/meta/gui/QOwnNotes.png
 Type=Application
 Terminal=false


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ubuntu/snappy-playpen/pull/230%23issuecomment-243811839%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/230%23issuecomment-243813941%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/230%23issuecomment-243814453%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/230%23issuecomment-243815596%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/230%23issuecomment-244122445%22%2C%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/230%23issuecomment-244330410%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ubuntu/snappy-playpen/pull/230%23issuecomment-243811839%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20it%20worth%20making%20that%20%5Cr%5CnExec%3D%24%7BSNAP%7D/qownnotes%5Cr%5CnSo%20it%20calls%20yours%2C%20no%20matter%20what%27s%20in%20the%20path%3F%22%2C%20%22created_at%22%3A%20%222016-08-31T15%3A59%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1841272%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/popey%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40popey%2C%20this%20is%20what%20the%20ubuntu%20store%20gave%20me%20with%20the%20old%20desktop%20file%20since%20yesterday%20%28still%20worked%20the%20day%20before%20yesterday%29%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5CnLaunchpad%20uploaded%20this%20snap%20package%20to%20the%20store%2C%20but%20the%20store%20failed%20to%5Cr%5Cnscan%20it%3A%5Cr%5Cn%20%27Exec%3Dusr/bin/QOwnNotes%27%20does%20not%20use%3A%20qownnotes%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnBut%20in%20any%20case%20and%20on%20top%20of%20that%2C%20when%20I%20now%20run%20%60qownnotes%60%20I%20get%20the%20error%20message%20%60multiple%20nvidia%20drivers%20detected%2C%20this%20is%20not%20supported%60.%20Although%20I%20can%20run%20the%20QOwnNotes%20binary%20directly%20from%20the%20snap%20directory...%20Any%20ideas%3F%20It%20all%20worked%20a%20few%20weeks%20ago%2C%20where%20I%20last%20tested%20it.%22%2C%20%22created_at%22%3A%20%222016-08-31T16%3A05%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22And%20%40popey%2C%20I%20wanted%20to%20thank%20you%20for%20all%20the%20effort%20you%20are%20putting%20in%20snaps%2C%20Ubuntu%20Mate%20and%20the%20whole%20open%20source%20ecosystem%21%22%2C%20%22created_at%22%3A%20%222016-08-31T16%3A07%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20%60multiple%20nvidia%20drivers%20detected%2C%20this%20is%20not%20supported%60%20error%20message%20seems%20to%20stem%20from%20a%20bug%20%3Chttps%3A//bugs.launchpad.net/snap-confine/%2Bbug/1615248%3E%20ogra%20in%20the%20snappy%20chatroom%20told%20me...%22%2C%20%22created_at%22%3A%20%222016-08-31T16%3A11%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40popey%2C%20I%20undid%20the%20Exec%20path%20change%20because%20of%20the%20Launchpad%20error%3A%20%60%27Exec%3D%24%7BSNAP%7D/qownnotes%27%20does%20not%20use%3A%20qownnotes%20lint-snap-v2_desktop_file%20%28QOwnNotes.desktop%29%60%2C%20we%20need%20to%20stay%20with%20%60qownnotes%60%22%2C%20%22created_at%22%3A%20%222016-09-01T15%3A47%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1798101%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pbek%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%20Merging%20now%21%22%2C%20%22created_at%22%3A%20%222016-09-02T09%3A39%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1346979%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dholbach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ubuntu/snappy-playpen/pull/230#issuecomment-243811839'>General Comment</a></b>
- <a href='https://github.com/popey'><img border=0 src='https://avatars.githubusercontent.com/u/1841272?v=3' height=16 width=16'></a> Is it worth making that
Exec=${SNAP}/qownnotes
So it calls yours, no matter what's in the path?
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> @popey, this is what the ubuntu store gave me with the old desktop file since yesterday (still worked the day before yesterday):
```
Launchpad uploaded this snap package to the store, but the store failed to
scan it:
'Exec=usr/bin/QOwnNotes' does not use: qownnotes
```
But in any case and on top of that, when I now run `qownnotes` I get the error message `multiple nvidia drivers detected, this is not supported`. Although I can run the QOwnNotes binary directly from the snap directory... Any ideas? It all worked a few weeks ago, where I last tested it.
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> And @popey, I wanted to thank you for all the effort you are putting in snaps, Ubuntu Mate and the whole open source ecosystem!
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> The `multiple nvidia drivers detected, this is not supported` error message seems to stem from a bug <https://bugs.launchpad.net/snap-confine/+bug/1615248> ogra in the snappy chatroom told me...
- <a href='https://github.com/pbek'><img border=0 src='https://avatars.githubusercontent.com/u/1798101?v=3' height=16 width=16'></a> @popey, I undid the Exec path change because of the Launchpad error: `'Exec=${SNAP}/qownnotes' does not use: qownnotes lint-snap-v2_desktop_file (QOwnNotes.desktop)`, we need to stay with `qownnotes`
- <a href='https://github.com/dholbach'><img border=0 src='https://avatars.githubusercontent.com/u/1346979?v=3' height=16 width=16'></a> Thanks. Merging now!


<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/230?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ubuntu/snappy-playpen/pull/230?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ubuntu/snappy-playpen/pull/230'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>