### PR TITLE
hellogl: trivial bare opengl app

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This project currently includes the following snaps:
 | :white_check_mark:  | `galculator`       |                           | autotools, gtk3           |
 | :white_check_mark:  | `gitter-im`        |                           | copy, gtk3, wget          |
 | :white_check_mark:  | `grive    `        |                           | cmake                     |
+| :white_check_mark:  | `hellogl  `        |                           | cmake, opengl             |
 | :white_check_mark:  | `healthcheck-toolbox interface` | [healthcheck-toolbox-example][healthcheck-toolbox-example] | dump |
 | :red_circle:        | `heroku`           |                           | go                        |
 | :white_check_mark:  | `hexchat`          | [unofficial-hexchat][unofficial-hexchat] | autotools, gtk2, perl, python2, lua |

--- a/hellogl/CMakeLists.txt
+++ b/hellogl/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(hellogl LANGUAGES C)
+find_package(OpenGL REQUIRED)
+find_package(GLUT REQUIRED)
+add_executable(hellogl hellogl.c)
+target_link_libraries(hellogl ${OPENGL_LIBRARIES} ${GLUT_LIBRARY})
+install(TARGETS hellogl DESTINATION bin)
+
+# FIXME: remove opengl-launch once base wrappers set LIBGL_DRIVERS_PATH
+# See https://bugs.launchpad.net/snappy/+bug/1584178
+install(PROGRAMS opengl-launch DESTINATION bin)

--- a/hellogl/README.md
+++ b/hellogl/README.md
@@ -1,0 +1,17 @@
+# hellogl snap
+
+This project creates a very small snap that demonstrates using OpenGL.
+It bundles a small wrapper called opengl-launcher which sets
+LIBGL_DRIVERS_PATH to avoid the runtime error
+libGL error: unable to load driver: i965_dri.so
+(see https://bugs.launchpad.net/snappy/+bug/1584178 )
+Hopefully the default snap wrapper will do that someday,
+but until then, this demo is a tiny example of how
+to work around that problem.
+
+If you're already bundling gtk or Qt, you don't need the workaround,
+as desktop-launch already sets LIBGL_DRIVERS_PATH.
+But bundling gtk or Qt greatly increases snap size,
+and seems to cause a minute-long startup delay on
+first run (it runs update-mime-database?).
+So avoiding it is nice for simple apps that don't need it.

--- a/hellogl/hellogl.c
+++ b/hellogl/hellogl.c
@@ -1,0 +1,25 @@
+#include <GL/glut.h>
+
+void displayMe(void)
+{
+    glClear(GL_COLOR_BUFFER_BIT);
+    glBegin(GL_POLYGON);
+        glVertex3f(0.0, 0.0, 0.0);
+        glVertex3f(0.5, 0.0, 0.0);
+        glVertex3f(0.5, 0.5, 0.0);
+        glVertex3f(0.0, 0.5, 0.0);
+    glEnd();
+    glFlush();
+}
+
+int main(int argc, char** argv)
+{
+    glutInit(&argc, argv);
+    glutInitDisplayMode(GLUT_SINGLE);
+    glutInitWindowSize(300, 300);
+    glutInitWindowPosition(100, 100);
+    glutCreateWindow("Hello world :D");
+    glutDisplayFunc(displayMe);
+    glutMainLoop();
+    return 0;
+}

--- a/hellogl/opengl-launch
+++ b/hellogl/opengl-launch
@@ -1,0 +1,12 @@
+#!/bin/sh
+# See https://bugs.launchpad.net/snappy/+bug/1584178
+
+case "$SNAP_ARCH" in
+amd64) ARCH="x86_64-linux-gnu";;
+armhf) ARCH="arm-linux-gnueabihf";;
+*)     ARCH="$SNAP_ARCH-linux-gnu";;
+esac
+
+# Tell libGL where to find the drivers
+export LIBGL_DRIVERS_PATH=$SNAP/usr/lib/$ARCH/dri
+exec "$@"

--- a/hellogl/snapcraft.yaml
+++ b/hellogl/snapcraft.yaml
@@ -1,0 +1,31 @@
+name: hellogl
+version: "0.1"
+summary: minimal opengl app
+description: puts up a square
+confinement: strict
+
+build-packages:
+  - freeglut3-dev
+  - gcc
+  - libc6-dev
+  - libgl1-mesa-dev
+  - libxi-dev
+  - libxmu-dev
+
+apps:
+  hellogl:
+    plugs:
+      - x11
+      - opengl
+    # FIXME: remove opengl-launch once base wrappers set LIBGL_DRIVERS_PATH
+    command: opengl-launch $SNAP/bin/hellogl
+    # Many apps do this instead, but it requires e.g. 'after: [desktop-gtk2]', which makes the snap huge
+    #command: desktop-launch $SNAP/bin/hellogl
+
+parts:
+  hellogl:
+    source: .
+    plugin: cmake
+    stage-packages:
+      # Pull in drivers to be pointed to by LIBGL_DRIVERS_PATH
+      - libgl1-mesa-dri


### PR DESCRIPTION
Includes minimalist opengl wrapper derived from the one in mesa-demos
